### PR TITLE
remove treewriter from process_base

### DIFF
--- a/pyjetty/alice_analysis/process/base/process_base.py
+++ b/pyjetty/alice_analysis/process/base/process_base.py
@@ -27,7 +27,6 @@ import fjcontrib
 from pyjetty.alice_analysis.process.base import common_base
 from pyjetty.alice_analysis.process.base import process_utils
 from pyjetty.alice_analysis.process.base import jet_info
-from pyjetty.mputils import treewriter
 
 ################################################################
 class ProcessBase(common_base.CommonBase):
@@ -319,10 +318,6 @@ class ProcessBase(common_base.CommonBase):
     for attr in dir(self):
       
       obj = getattr(self, attr)
-      
-      # If tree writer object, get the tree it contains
-      if isinstance(obj, treewriter.RTreeWriter):
-        obj = obj.tree
       
       # Write all ROOT histograms and trees to file
       types = (ROOT.TH1, ROOT.THnBase, ROOT.TTree)


### PR DESCRIPTION
I don't think either of you (@ezradlesser @matplo ) were using trees in the alice_analysis processing classes...but removing this for now, so that alice_analysis does not depend on any modules outside of itself. Can always add it back in a more organized way if we want.