### PR TITLE
add generator-specific options to converter

### DIFF
--- a/pyjetty/alice_analysis/generation/hepmc2antuple_tn.py
+++ b/pyjetty/alice_analysis/generation/hepmc2antuple_tn.py
@@ -11,22 +11,44 @@ import pyhepmc_ng
 import ROOT
 ROOT.gROOT.SetBatch(True)
 
+import select_particles
+
 # jit improves execution time by 18% - tested with jetty pythia8 events
 # BUT produces invalid root file
 # from numba import jit
 # @jit
 
-def fill_event(run_number, ev_id, event_hepmc, tw_e, tw_p, pdg):
+#---------------------------------------------------------------
+def fill_event(run_number, ev_id, event_hepmc, tw_e, tw_p, pdg, gen, particles_accepted):
+
   tw_e.Fill(run_number, ev_id, 0, 0)
 
   for part in event_hepmc.particles:
-    if part.status == 1 and not part.end_vertex and pdg.GetParticle(part.pid).Charge() != 0:
-      # print(pdg.GetParticle(p.pid).GetName())
-      # tlv = ROOT.TLorentzVector()
-      # tlv.SetPxPyPzE(p.momentum.px, p.momentum.py, p.momentum.pz, p.momentum.e)
+  
+    if accept_particle(part, pdg, gen):
+    
+      particles_accepted.add(pdg.GetParticle(part.pid).GetName())
       tw_p.Fill(run_number, ev_id, part.momentum.pt(), part.momentum.eta(), part.momentum.phi(), part.pid)
+ 
+#---------------------------------------------------------------
+def accept_particle(part, pdg, gen):
 
+  if gen == 'pythia':
+    return select_particles.accept_particle_pythia(part, pdg)
+  if gen == 'herwig':
+    return select_particles.accept_particle_herwig(part, pdg)
+  if gen == 'jewel':
+    return select_particles.accept_particle_jewel(part, pdg)
+  elif gen == 'jetscape':
+    return select_particles.accept_particle_jetscape(part, pdg)
+  elif gen == 'martini':
+    return select_particles.accept_particle_martini(part, pdg)
+  elif gen == 'hybrid':
+    return select_particles.accept_particle_hybrid(part, pdg)
+  else:
+    sys.exit('Generator type unknown: {}'.format(gen))
 
+#---------------------------------------------------------------
 def main():
   parser = argparse.ArgumentParser(description='hepmc to ALICE Ntuple format', prog=os.path.basename(__file__))
   parser.add_argument('-i', '--input', help='input file', default='', type=str, required=True)
@@ -34,6 +56,7 @@ def main():
   parser.add_argument('--as-data', help='write as data - tree naming convention', action='store_true', default=False)
   parser.add_argument('--hepmc', help='what format 2 or 3', default=2, type=int)
   parser.add_argument('--nev', help='number of events', default=-1, type=int)
+  parser.add_argument('-g', '--gen', help='generator type: pythia, herwig, jewel, jetscape, martini, hybrid', default='pythia', type=str, required=True)
   parser.add_argument('--no-progress-bar', help='whether to print progress bar', action='store_true', default=False)
   args = parser.parse_args()
 
@@ -73,12 +96,13 @@ def main():
     else:
       pbar = tqdm.tqdm()
 
+  particles_accepted = set([])
   while not input_hepmc.failed():
     ev = input_hepmc.read_event(event_hepmc)
     if input_hepmc.failed():
       break
 
-    fill_event(run_number, ev_id, event_hepmc, t_e, t_p, pdg)
+    fill_event(run_number, ev_id, event_hepmc, t_e, t_p, pdg, args.gen, particles_accepted)
 
     ev_id = ev_id + 1
     if not args.no_progress_bar:
@@ -88,9 +112,24 @@ def main():
         print('event {}'.format(ev_id))
     if args.nev > 0 and ev_id > args.nev:
       break
+      
+  # Print final list of particles that we accepted
+  print('particles included: {}'.format(particles_accepted))
+  reference_particles = ['Omega+', 'Xi-', 'e+', 'Sigma-', 'mu-', 'Omega-', 'antiproton', 'proton', 'mu+', 'Sigma+', 'Sigma-_bar', 'Sigma+_bar', 'K-', 'pi+', 'K+', 'pi-', 'e-', 'Xi-_bar']
+  
+  # Check that we are not missing any particles
+  for particle in reference_particles:
+    if particle not in particles_accepted:
+      print('WARNING: {} not found in your accepted particles!'.format(particle))
+      
+  # Check that we do not have any extra particles
+  for particle in particles_accepted:
+    if particle not in reference_particles:
+      print('WARNING: {} was found in your accepted particles!'.format(particle))
 
   outf.Write()
   outf.Close()
 
+#---------------------------------------------------------------
 if __name__ == '__main__':
   main()

--- a/pyjetty/alice_analysis/generation/select_particles.py
+++ b/pyjetty/alice_analysis/generation/select_particles.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+import os
+import pyhepmc_ng
+
+import ROOT
+ROOT.gROOT.SetBatch(True)
+
+#---------------------------------------------------------------
+def accept_particle_pythia(part, pdg):
+
+  return accept_particle_status(part, pdg, status = [1])
+  
+#---------------------------------------------------------------
+def accept_particle_herwig(part, pdg):
+
+  return accept_particle_status(part, pdg, status = [1])
+  
+#---------------------------------------------------------------
+def accept_particle_jewel(part, pdg):
+
+  return accept_particle_status(part, pdg, status = [1])
+  
+#---------------------------------------------------------------
+def accept_particle_martini(part, pdg):
+  '''
+  Status codes:
+    parton: 1
+    hadron: 201
+    recoil: 301
+    negative particles: 401
+  '''
+  
+  return accept_particle_status(part, pdg, status = [201])
+  
+#---------------------------------------------------------------
+def accept_particle_hybrid(part, pdg):
+  '''
+  Status codes:
+    hadron: 1
+    wake, positive: 6
+    wake, negative: 7
+  '''
+  
+  return accept_particle_status(part, pdg, status = [1, 6, 7])
+  
+#---------------------------------------------------------------
+def accept_particle_status(part, pdg, status = [1]):
+  
+  # Check status
+  #print('status: {}'.format(part.status))
+  if part.status not in status:
+    return False
+  
+  # Check that particle does not have any daughter vertex
+  #print(part.end_vertex)
+  if part.end_vertex:
+    return False
+  
+  # Check PID for charged particles
+  #print('pid: {} = {}'.format(part.pid, pdg.GetParticle(part.pid).GetName()))
+  if pdg.GetParticle(part.pid).Charge() == 0:
+    return False
+    
+  return True
+
+#---------------------------------------------------------------
+def accept_particle_jetscape(part, pdg):
+  
+  # The final-state hadrons are stored as outgoing particles in a disjoint vertex with t = 100
+  parent_vertex = part.production_vertex
+  vertex_time = parent_vertex.position.t
+  if abs(vertex_time - 100) > 1e-3:
+    return False
+  
+  # Check PID for charged particles, and reject neutrinos
+  #print('pid: {} = {}'.format(part.pid, pdg.GetParticle(part.pid).GetName()))
+  if pdg.GetParticle(part.pid).Charge() == 0:
+    return False
+
+  return True


### PR DESCRIPTION
Add a command-line option `--gen <generator>` to select accepted particles based on the generator. Adds a separate module to do the selections, and also prints out warnings if the selected particle list does not match what we expect.

Options implemented:
* pythia
* herwig 
* jewel 
* jetscape
* martini
* hybrid

Note that treating recoil needs some thought -- the acceptance functions for each generator are subject to change for jewel/martini/hybrid -- but should be trustable for pythia/herwig/jetscape.

Also: The HepMC parser only seems to work for pythia/herwig/jetscape, but not the others. 