### PR TITLE
Fix bug in sys uncertainty in last bin

### DIFF
--- a/pyjetty/alice_analysis/analysis/user/substructure/run_analysis.py
+++ b/pyjetty/alice_analysis/analysis/user/substructure/run_analysis.py
@@ -947,7 +947,7 @@ class RunAnalysis(common_base.CommonBase):
   #----------------------------------------------------------------------
   def change_to_per(self, h):
 
-    for bin in range(0, h.GetNbinsX()):
+    for bin in range(0, h.GetNbinsX()+2):
       content = h.GetBinContent(bin)
       content_new = math.fabs(1-content)
       h.SetBinContent(bin, content_new*100)


### PR DESCRIPTION
The systematic uncertainty in the last bin was not properly converted to percentage

@ezradlesser I don't think this affects you since you truncate your hists before the last bin.