### PR TITLE
add RooUnfold to fjtools, and work on rebinning function

### DIFF
--- a/cpptools/src/fjtools/CMakeLists.txt
+++ b/cpptools/src/fjtools/CMakeLists.txt
@@ -10,9 +10,14 @@ message(STATUS "SOURCES: ${SOURCES_LIB}")
 string(REPLACE ".cxx" ".hh" HEADERS_LIB "${SOURCES_LIB}")
 string(REPLACE ".cxx" "_wrap.c" SWIG_HEADERS_LIB "${SOURCES_LIB}")
 
+# Define preprocessor command for .hh include statement
+if (${RooUnfold_FOUND})
+  add_compile_definitions(USE_ROOUNFOLD=ON)
+endif(${RooUnfold_FOUND})
+
 add_library(${NAME_LIB} SHARED ${SOURCES_LIB})
-target_include_directories(${NAME_LIB} PUBLIC ${FASTJET_DIR}/include ${ROOT_INCLUDE_DIRS})
-target_link_libraries(${NAME_LIB} PUBLIC ${FASTJET_LIBS} ${ROOT_LIBRARIES})
+target_include_directories(${NAME_LIB} PUBLIC ${FASTJET_DIR}/include ${ROOT_INCLUDE_DIRS} ${ROOUNFOLD_INCLUDE_DIR})
+target_link_libraries(${NAME_LIB} PUBLIC ${FASTJET_LIBS} ${ROOT_LIBRARIES} ${ROOUNFOLD_LIBRARIES})
 
 set(SWIG_TARGET_LINK_LIBRARIES "${FASTJET_LIBS} ${ROOT_LIBRARIES}")
 

--- a/cpptools/src/fjtools/fjtools.hh
+++ b/cpptools/src/fjtools/fjtools.hh
@@ -8,6 +8,10 @@ class TH2F;
 #include <vector>
 #include <fastjet/PseudoJet.hh>
 
+#ifdef USE_ROOUNFOLD
+#include <RooUnfoldResponse.h>
+#endif
+
 namespace PyJettyFJTools
 {
 	class BoltzmannBackground
@@ -60,18 +64,35 @@ namespace PyJettyFJTools
 
 	// Rebin N-dimensional THn to a new histogram with name name_thn_rebinned using provided axes
 	// WARNING: currently requires n_dim = 4
-	THnF* rebin_thn(THnF* thn, const std::string & name_thn_rebinned,
-					const unsigned int & n_dim, const int* axes_n_bins,
-					double** axes_bin_arrays, const double & prior_variation_parameter=0.,
-					bool move_underflow=false, bool do_roounfoldresponse=true);
+	THnF* rebin_thn(std::string response_file_name,
+                    THnF* thn,
+                    const std::string & name_thn_rebinned,
+                    const std::string & name_roounfold,
+					const unsigned int & n_dim,
+                    const int* axes_n_bins,
+					double** axes_bin_arrays,
+                    const std::string label="",
+                    const double & prior_variation_parameter=0.,
+                    int prior_option=1,
+					bool move_underflow=false,
+                    bool do_roounfoldresponse=true);
 
 	// Create empty THn using provided axes
 	THnF* create_empty_thn(const char* name, const unsigned int & n_dim, const char** axes_titles,
 						   const int* axes_n_bins, double** axes_bin_arrays);
 
 	// Fill empty thn_rebinned with data from thn
-	void fill_rebinned_thn(THnF* thn, THnF* thn_rebinned, const unsigned int & n_dim,
-						   const double & prior_variation_parameter=0., bool move_underflow=false);
+	void fill_rebinned_thn(std::string response_file_name, THnF* thn,
+                           THnF* thn_rebinned, const unsigned int & n_dim,
+                           bool do_roounfoldresponse=true,
+                           RooUnfoldResponse* roounfold_response=nullptr,
+						   const double & prior_variation_parameter=0.,
+                           int prior_option=1,
+                           bool move_underflow=false);
+
+    // Set scaling of prior
+    double prior_scale_factor_obs(double obs_true, double content,
+                                  double prior_variation_parameter, int option);
 
 };
 


### PR DESCRIPTION
Thanks to @matplo we can now build RooUnfold in heppy (with `external/roounfold/build.h`).

This commit is including RooUnfold in pyjetty's fjtools. 

@ezradlesser I haven't tested whether the rebinning function actually works, just that it compiles. 
I will have a look next week but feel free in the meantime to test/modify.