### PR TITLE
keep fjtools working without roounfold

### DIFF
--- a/cpptools/src/fjtools/CMakeLists.txt
+++ b/cpptools/src/fjtools/CMakeLists.txt
@@ -10,14 +10,18 @@ message(STATUS "SOURCES: ${SOURCES_LIB}")
 string(REPLACE ".cxx" ".hh" HEADERS_LIB "${SOURCES_LIB}")
 string(REPLACE ".cxx" "_wrap.c" SWIG_HEADERS_LIB "${SOURCES_LIB}")
 
-# Define preprocessor command for .hh include statement
-if (${RooUnfold_FOUND})
-  add_compile_definitions(USE_ROOUNFOLD=ON)
-endif(${RooUnfold_FOUND})
-
 add_library(${NAME_LIB} SHARED ${SOURCES_LIB})
-target_include_directories(${NAME_LIB} PUBLIC ${FASTJET_DIR}/include ${ROOT_INCLUDE_DIRS} ${ROOUNFOLD_INCLUDE_DIR})
-target_link_libraries(${NAME_LIB} PUBLIC ${FASTJET_LIBS} ${ROOT_LIBRARIES} ${ROOUNFOLD_LIBRARIES})
+
+# Define preprocessor command for .hh include statement
+# And set include/link directories appropriately
+if(${RooUnfold_FOUND})
+  add_compile_definitions(USE_ROOUNFOLD=ON)
+  target_include_directories(${NAME_LIB} PUBLIC ${FASTJET_DIR}/include ${ROOT_INCLUDE_DIRS} ${ROOUNFOLD_INCLUDE_DIR})
+  target_link_libraries(${NAME_LIB} PUBLIC ${FASTJET_LIBS} ${ROOT_LIBRARIES} ${ROOUNFOLD_LIBRARIES})
+else(${RooUnfold_FOUND})
+  target_include_directories(${NAME_LIB} PUBLIC ${FASTJET_DIR}/include ${ROOT_INCLUDE_DIRS})
+  target_link_libraries(${NAME_LIB} PUBLIC ${FASTJET_LIBS} ${ROOT_LIBRARIES} )
+endif(${RooUnfold_FOUND})
 
 set(SWIG_TARGET_LINK_LIBRARIES "${FASTJET_LIBS} ${ROOT_LIBRARIES}")
 

--- a/cpptools/src/fjtools/fjtools.cxx
+++ b/cpptools/src/fjtools/fjtools.cxx
@@ -119,7 +119,8 @@ namespace PyJettyFJTools
 
     }  // rebin_th2
 
-	
+
+#ifdef USE_ROOUNFOLD
 	//---------------------------------------------------------------
 	// Rebin THn according to specified binnings; return pointer to rebinned THn
 	//---------------------------------------------------------------
@@ -328,6 +329,7 @@ namespace PyJettyFJTools
 		return;
 
 	}  // fill_rebinned_thn
+#endif
 
     //---------------------------------------------------------------
     // Compute scale factor to vary prior of observable

--- a/cpptools/src/fjtools/fjtools.hh
+++ b/cpptools/src/fjtools/fjtools.hh
@@ -62,6 +62,7 @@ namespace PyJettyFJTools
     TH2F* rebin_th2(TH2F* h, std::string hname, int n_x_bins, double* x_bins,
                     int n_y_bins, double* y_bins, bool move_y_underflow = false);
 
+#ifdef USE_ROOUNFOLD
 	// Rebin N-dimensional THn to a new histogram with name name_thn_rebinned using provided axes
 	// WARNING: currently requires n_dim = 4
 	THnF* rebin_thn(std::string response_file_name,
@@ -89,6 +90,7 @@ namespace PyJettyFJTools
 						   const double & prior_variation_parameter=0.,
                            int prior_option=1,
                            bool move_underflow=false);
+#endif
 
     // Set scaling of prior
     double prior_scale_factor_obs(double obs_true, double content,


### PR DESCRIPTION
some minor changes to make sure pyjetty still builds even if roounfold isn't installed

FYI @matplo @ezradlesser 