### PR TITLE
revert to requiring roounfold

### DIFF
--- a/cpptools/src/fjtools/CMakeLists.txt
+++ b/cpptools/src/fjtools/CMakeLists.txt
@@ -15,13 +15,14 @@ add_library(${NAME_LIB} SHARED ${SOURCES_LIB})
 # Define preprocessor command for .hh include statement
 # And set include/link directories appropriately
 if(${RooUnfold_FOUND})
-  add_compile_definitions(USE_ROOUNFOLD=ON)
+  add_compile_definitions(USE_ROOUNFOLD=1)
   target_include_directories(${NAME_LIB} PUBLIC ${FASTJET_DIR}/include ${ROOT_INCLUDE_DIRS} ${ROOUNFOLD_INCLUDE_DIR})
   target_link_libraries(${NAME_LIB} PUBLIC ${FASTJET_LIBS} ${ROOT_LIBRARIES} ${ROOUNFOLD_LIBRARIES})
-else(${RooUnfold_FOUND})
+else()
+  add_compile_definitions(USE_ROOUNFOLD=0)
   target_include_directories(${NAME_LIB} PUBLIC ${FASTJET_DIR}/include ${ROOT_INCLUDE_DIRS})
   target_link_libraries(${NAME_LIB} PUBLIC ${FASTJET_LIBS} ${ROOT_LIBRARIES} )
-endif(${RooUnfold_FOUND})
+endif()
 
 set(SWIG_TARGET_LINK_LIBRARIES "${FASTJET_LIBS} ${ROOT_LIBRARIES}")
 

--- a/cpptools/src/fjtools/fjtools.cxx
+++ b/cpptools/src/fjtools/fjtools.cxx
@@ -117,8 +117,6 @@ namespace PyJettyFJTools
 
     }  // rebin_th2
 
-
-#ifdef USE_ROOUNFOLD
     //---------------------------------------------------------------
     // Rebin THn according to specified binnings; return pointer to rebinned THn
     //---------------------------------------------------------------
@@ -323,7 +321,6 @@ namespace PyJettyFJTools
         return;
 
     }  // fill_rebinned_thn
-#endif
 
     //---------------------------------------------------------------
     // Compute scale factor to vary prior of observable

--- a/cpptools/src/fjtools/fjtools.hh
+++ b/cpptools/src/fjtools/fjtools.hh
@@ -8,7 +8,7 @@ class TF1;
 #include <vector>
 #include <fastjet/PseudoJet.hh>
 
-#ifdef USE_ROOUNFOLD
+#if USE_ROOUNFOLD
 #include <RooUnfoldResponse.h>
 #endif
 
@@ -62,7 +62,6 @@ namespace PyJettyFJTools
     TH2F* rebin_th2(TH2F & h_to_rebin, char* hname, double* x_bins, int n_x_bins,
                     double* y_bins, int n_y_bins, bool move_y_underflow = false);
 
-#ifdef USE_ROOUNFOLD
 	// Rebin N-dimensional THn to a new histogram with name name_thn_rebinned using provided axes
 	// WARNING: currently requires n_dim = 4
 	THnF* rebin_thn(std::string response_file_name,
@@ -90,7 +89,6 @@ namespace PyJettyFJTools
 						   const double & prior_variation_parameter=0.,
                            int prior_option=1,
                            bool move_underflow=false);
-#endif
 
     // Set scaling of prior
     double prior_scale_factor_obs(double obs_true, double content,


### PR DESCRIPTION
turns out #54 still had some cmake issues...after wasting a long time battling cmake I'm going to revert to requiring RooUnfold as a requirement of pyjetty...

in principle it should not be hard to keep it optional...although for reasons beyond me I couldn't get preprocessor directives to work...suggestions welcome.

@matplo @ezradlesser 