### PR TITLE
Angularities: F_np and groomed theory comparisons

### DIFF
--- a/cpptools/src/rutil/rutil.hh
+++ b/cpptools/src/rutil/rutil.hh
@@ -85,9 +85,11 @@ namespace RUtil
 		// Create and return 2D histogram, convolving h with shape function
 		TH2D* convolve_F_np(const double & Omega, const double & R, const double & beta,
 							const double* ob_bins, const int & n_ob_bins, const double* obs,
+							const double* ob_bin_width,
 							const double* pT_bins, const int & n_pT_bins, const double* pTs,
 							const TH2D & h, const std::string & name, const bool groomed = false,
-							const double & sd_beta = 0, const double & sd_zcut = 0.2);
+							const double & sd_beta = 0, const double & sd_zcut = 0.2,
+							const std::string & option = "");
 
     private:
         // Create empty THn using provided axes

--- a/cpptools/src/rutil/rutil.hh
+++ b/cpptools/src/rutil/rutil.hh
@@ -58,6 +58,10 @@ namespace RUtil
         TH2F* rebin_th2(TH2F & h_to_rebin, char* hname, double* x_bins, int n_x_bins,
                         double* y_bins, int n_y_bins, bool move_y_underflow = false);
 
+        // Rebin 2D histogram h with name hname using axes given by x_bins and y_bins
+        TH2D* rebin_th2(TH2D & h_to_rebin, char* hname, double* x_bins, int n_x_bins,
+                        double* y_bins, int n_y_bins, bool move_y_underflow = false);
+
         // Rebin N-dimensional THn to a new histogram with name name_thn_rebinned using provided axes
         // WARNING: currently requires n_dim = 4
         THnF* rebin_thn(const std::string & response_file_name,

--- a/cpptools/src/rutil/rutil.hh
+++ b/cpptools/src/rutil/rutil.hh
@@ -79,6 +79,16 @@ namespace RUtil
                         const bool move_underflow=false,
                         const bool do_roounfoldresponse=true);
 
+		//------------------------------------------------------
+		// Convolution of nonperturbative shape functions
+
+		// Create and return 2D histogram, convolving h with shape function
+		TH2D* convolve_F_np(const double & Omega, const double & R, const double & beta,
+							const double* ob_bins, const int & n_ob_bins, const double* obs,
+							const double* pT_bins, const int & n_pT_bins, const double* pTs,
+							const TH2D & h, const std::string & name, const bool groomed = false,
+							const double & sd_beta = 0, const double & sd_zcut = 0.2);
+
     private:
         // Create empty THn using provided axes
         THnF* create_empty_thn(const char* name, const int & n_dim,
@@ -101,6 +111,16 @@ namespace RUtil
 
         // Set scaling of prior
         prior_scale_func prior_scale_factor_obs(const int & option);
+
+		//------------------------------------------------------
+		// Convolution of nonperturbative shape functions
+
+        // Non-perturbative parameter with factored-out beta dependence
+        // Omega is Omega_{a=0} == Omega_{beta=2}  (universal[?])
+		inline double Omega_beta(const double & Omega, const double & beta);
+
+		// Shape function for convolving nonperturbative effects
+		inline double F_np(const double & Omega, const double & k, const double & beta);
 
     ClassDef(HistUtils, 1)
     };

--- a/pyjetty/alice_analysis/analysis/user/ang_pp/plot_angularity_theory_figures.py
+++ b/pyjetty/alice_analysis/analysis/user/ang_pp/plot_angularity_theory_figures.py
@@ -391,7 +391,7 @@ class PlotAngularityFigures(common_base.CommonBase):
             self.g_theory_dict[beta][i].SetLineWidth(3)
             self.g_theory_dict[beta][i].Draw('L 3 same')
             
-            leg.AddEntry(self.g_theory_dict[beta][i],'NLO+NLL #otimes {}'.format(folding_label),'lf')
+            leg.AddEntry(self.g_theory_dict[beta][i],'NLL\' #otimes {}'.format(folding_label),'lf')
             
         self.h_sys.Draw('E2 same')
         if not groomed:

--- a/pyjetty/alice_analysis/analysis/user/ang_pp/plot_angularity_theory_figures.py
+++ b/pyjetty/alice_analysis/analysis/user/ang_pp/plot_angularity_theory_figures.py
@@ -1,0 +1,648 @@
+"""
+  macro for plotting multi-paneled angularity figures
+  """
+
+# General
+import os
+import sys
+import math
+import yaml
+import argparse
+
+# Data analysis and plotting
+import ROOT
+import numpy as np
+from array import *
+
+# Base class
+from pyjetty.alice_analysis.analysis.base import common_base
+
+# Prevent ROOT from stealing focus when plotting
+ROOT.gROOT.SetBatch(True)
+
+################################################################
+class PlotAngularityFigures(common_base.CommonBase):
+
+    # ---------------------------------------------------------------
+    # Constructor
+    # ---------------------------------------------------------------
+    def __init__(self, output_dir='', **kwargs):
+        super(PlotAngularityFigures, self).__init__(**kwargs)
+
+        self.output_dir = output_dir
+        self.file_format = '.pdf'
+
+        #------------------------------------------------------
+
+        #self.base_dir = '/home/james/plot-angularity/'
+        self.base_dir = '~/'
+        self.file = 'ang/final_results/fFinalResults.root'
+        self.beta_list = [1.5, 2, 3]
+        self.R_list = [0.2, 0.4]
+        self.min_pt = 60
+        self.max_pt = 80
+        self.folding_labels = ['PYTHIA8', 'Herwig7']
+
+        self.xmin = -0.01
+        self.ymax = 18.99
+        self.ymin_ratio = 0.1
+        self.ymax_ratio = 15
+        self.scale_factor_groomed_beta3 = 0.04
+        self.scale_factor_groomed_beta2 = 0.2
+        self.scale_factor_groomed_beta15 = 0.5
+        self.scale_factor_ungroomed_beta2 = 0.5
+        self.scale_factor_ungroomed_beta3 = 0.1
+
+        self.xtitle =  '#it{#lambda}_{#it{#beta}}'
+        self.ytitle = '#frac{d#it{#sigma}}{d#it{#lambda}_{#it{#beta}}} #/#int_{#it{#lambda}_{#it{#beta}}^{NP}}^{1} #frac{d#it{#sigma}}{d#it{#lambda}_{#it{#beta}}} d#it{#lambda}_{#it{#beta}}'
+        self.xtitle_groomed =  '#it{#lambda}_{#it{#beta},g}'
+        self.ytitle_groomed = '#frac{1}{#it{#sigma}_{jet}} #frac{d#it{#sigma}}{d#it{#lambda}_{#it{#beta},g}}'
+
+        self.left_offset = 0.4
+        self.bottom_offset = 0.15
+        self.ratio_height = 0.25
+        self.top_bottom_scale_factor = (1 - self.ratio_height) / (1 - self.bottom_offset - self.ratio_height)
+
+        #------------------------------------------------------
+
+        self.marker_data = 21
+        self.markers = [20, 34, 33, 22, 23]
+        self.marker_size = 3
+        self.marker_size_ratio = 2
+        self.alpha = 0.7
+        self.color_data = 1
+        self.colors = [ROOT.kRed-7, ROOT.kTeal-8, ROOT.kViolet-8, ROOT.kBlue-9]
+        
+        #------------------------------------------------------
+
+        # P vs NP cutoff point: lambda_beta ~ Lambda / (pT * R) -- use avg value of pT for the bin.
+        # Formula assumes that jet pT xsec falls like pT^(-5.5)
+        formula_pt = (4.5/3.5)*(self.min_pt**-3.5 - self.max_pt**-3.5)/(self.min_pt**-4.5 - self.max_pt**-4.5)
+        self.Lambda = 1.
+        self.lambda_np = {}
+        for R in self.R_list:
+            self.lambda_np[R] = round(self.Lambda / (formula_pt * R), 2)
+
+        #------------------------------------------------------
+        # Store paths to all final results in a dictionary
+        self.predictions = {}
+        
+        subdir_path = os.path.join(self.base_dir, 'AngR02_ptbin3')
+        filename = os.path.join(subdir_path, 'ang/final_results/fFinalResults.root')
+        self.predictions['0.2'] = filename
+
+        subdir_path = os.path.join(self.base_dir, 'AngR04_ptbin3')
+        filename = os.path.join(subdir_path, 'ang/final_results/fFinalResults.root')
+        self.predictions['0.4'] = filename
+
+        print(self)
+
+    #-------------------------------------------------------------------------------------------
+    #-------------------------------------------------------------------------------------------
+    #-------------------------------------------------------------------------------------------
+    def plot_results(self):
+
+        self.setOptions()
+        ROOT.gROOT.ForceStyle()
+
+        self.plot_multipanel(R=0.2, groomed=False)
+        self.plot_multipanel(R=0.4, groomed=False)
+
+    #-------------------------------------------------------------------------------------------
+    def plot_multipanel(self, R=1, groomed=False):
+
+        # Create multi-panel canvas
+        cname = 'c{}{}'.format(R,groomed)
+        c = ROOT.TCanvas(cname,cname,2400,1400)
+        c.SetRightMargin(0.05);
+        c.SetLeftMargin(self.left_offset);
+        c.SetTopMargin(0.03);
+        c.SetBottomMargin(self.bottom_offset/2);
+        c.cd()
+        c.Divide(3, 1, 0.01, 0.)
+
+        # Keep histograms in memory, otherwise there can be problems with double deletes (i.e. ROOT then python deletes)
+        self.plot_list = []
+        self.g_theory_dict = {'1.5': [], '2': [], '3': []}
+        self.h_ratio_dict = {'1.5': [], '2': [], '3': []}
+        self.g_ratio_dict = {'1.5': [], '2': [], '3': []}
+
+        # Plot each pt bin in its own pad
+        self.plot_angularity(c, pad=1, R=R, beta = '1.5', groomed=groomed)
+        self.plot_angularity(c, pad=2, R=R, beta = '2',   groomed=groomed)
+        self.plot_angularity(c, pad=3, R=R, beta = '3',   groomed=groomed)
+
+        if groomed:
+            outfilename = 'hJetAngularity_Theory_{}_SD{}'.format(R, self.file_format)
+        else:
+            outfilename = 'hJetAngularity_Theory_{}{}'.format(R, self.file_format)
+        output_filename = os.path.join(self.output_dir, outfilename)
+        c.SaveAs(output_filename)
+
+    #-------------------------------------------------------------------------------------------
+    # Get beta histograms from file, and call plot_beta_overlay to draw them
+    #-------------------------------------------------------------------------------------------
+    def plot_angularity(self, c, pad=0, R=1, beta = '', groomed=False):
+        
+        filename = self.predictions[str(R)]
+        f = ROOT.TFile(filename, 'READ')
+
+        self.h = None
+        self.h_sys = None
+        self.blank_histo_list = []
+
+        grooming_label = ''
+        if groomed:
+            grooming_label = '_SD_zcut02_B0'
+            
+        # Get data hist
+        h_name ='hmain_ang_R{}_{}{}_{}-{}_trunc'.format(
+            R, beta, grooming_label, self.min_pt, self.max_pt)
+        h_sys_name =  'hResult_ang_systotal_R{}_{}{}_n3_{}-{}'.format(
+            R, beta, grooming_label, self.min_pt, self.max_pt)
+        self.h = f.Get(h_name)
+        self.h_sys = f.Get(h_sys_name)
+        self.h.SetDirectory(0)
+        self.h_sys.SetDirectory(0)
+        
+        # Normalize such that integral in perturbative region is 1
+        n = self.h.GetNbinsX()
+        min_bin = self.h.FindBin(self.lambda_np[R] - 0.001) + 1
+        integral_perturbative = self.h.Integral(min_bin, n+1, 'width')
+        self.h.Scale(1./integral_perturbative)
+        self.h_sys.Scale(1./integral_perturbative)
+        
+        self.scale_label = self.scale_histogram_for_visualization(self.h_sys, beta, groomed)
+        self.scale_histogram_for_visualization(self.h, beta, groomed)
+        
+        # Get folded theory predictions
+        for i,folding_label in enumerate(self.folding_labels):
+
+            beta_label = beta
+            if beta == '1.5':
+                beta_label = 15
+            name_cent = 'theory_cent_ang_R{}_{}_ch_PtBin60-80_{}'.format(
+                self.remove_periods(str(R)), beta_label, i)
+            name_min = 'theory_min_ang_R{}_{}_ch_PtBin60-80_{}'.format(
+                self.remove_periods(str(R)), beta_label, i)
+            name_max = 'theory_max_ang_R{}_{}_ch_PtBin60-80_{}'.format(
+                self.remove_periods(str(R)), beta_label, i)
+            
+            h_theory_cent = f.Get(name_cent)
+            h_theory_min = f.Get(name_min)
+            h_theory_max = f.Get(name_max)
+            h_theory_cent.SetDirectory(0)
+            h_theory_min.SetDirectory(0)
+            h_theory_max.SetDirectory(0)
+            
+            # Rebin to data binning
+            h_theory_cent_rebinned = self.rebin_theory(h_theory_cent, self.h)
+            h_theory_min_rebinned = self.rebin_theory(h_theory_min, self.h)
+            h_theory_max_rebinned = self.rebin_theory(h_theory_max, self.h)
+            
+            # Normalize such that integral in perturbative region is 1
+            min_bin =  h_theory_cent_rebinned.FindBin(self.lambda_np[R]-0.001) + 1
+            integral_perturbative_theory =  h_theory_cent_rebinned.Integral(min_bin, n+1, 'width')
+            integral_total =  h_theory_cent_rebinned.Integral(1, n+1, 'width')
+
+            h_theory_cent_rebinned.Scale(1./integral_perturbative_theory)
+            h_theory_min_rebinned.Scale(1./integral_perturbative_theory)
+            h_theory_max_rebinned.Scale(1./integral_perturbative_theory)
+                        
+            # Scale additionally for visualization
+            self.scale_histogram_for_visualization(h_theory_cent_rebinned, beta, groomed)
+            self.scale_histogram_for_visualization(h_theory_min_rebinned, beta, groomed)
+            self.scale_histogram_for_visualization(h_theory_max_rebinned, beta, groomed)
+            
+            x = np.array([h_theory_cent_rebinned.GetXaxis().GetBinCenter(i) for i in range(1, n+1)])
+            y = np.array([h_theory_cent_rebinned.GetBinContent(i) for i in range(1, n+1)])
+            xerrup = xerrdn = np.array([0. for i in range(n)])
+            yerrup = np.array([h_theory_max_rebinned.GetBinContent(i)-y[i-1] for i in range(1, n+1)])
+            yerrdn = np.array([y[i-1]-h_theory_min_rebinned.GetBinContent(i) for i in range(1, n+1)])
+            g_theory = ROOT.TGraphAsymmErrors(n, x, y, xerrdn, xerrup, yerrdn, yerrup)
+            g_theory.SetName('g_theory_{}_{}'.format(i, beta))
+            self.g_theory_dict[beta].append(g_theory)
+
+            # Construct ratios in self.h_ratio_dict, self.g_ratio_dict
+            self.construct_ratio(self.h, self.h_sys, h_theory_cent_rebinned, h_theory_min_rebinned,
+                                 h_theory_max_rebinned, n, x, xerrup, xerrdn, y, yerrup, yerrdn, R, beta, i, pad)
+            
+        f.Close()
+
+        # Plot overlay of beta values
+        self.plot_beta_overlay(c, pad, R, beta, groomed)
+
+        # Keep histograms in memory
+        self.plot_list.append(self.h)
+        self.plot_list.append(self.h_sys)
+        self.plot_list.append(self.g_theory_dict)
+        self.plot_list.append(self.h_ratio_dict)
+        self.plot_list.append(self.g_ratio_dict)
+        self.plot_list.append(self.blank_histo_list)
+
+    #-------------------------------------------------------------------------------------------
+    # Draw beta histograms in given pad
+    #-------------------------------------------------------------------------------------------
+    def plot_beta_overlay(self, c, pad, R, beta, groomed):
+
+        # Create canvas
+        c.cd(pad)
+
+        # Set pad to plot distributions
+        pad1 = ROOT.TPad("pad1_{}".format(R), "pad1{}".format(R),0, self.bottom_offset + self.ratio_height,1,1)
+        self.plot_list.append(pad1)
+        if pad in [1]:
+            pad1.SetLeftMargin(self.left_offset)
+        else:
+            pad1.SetLeftMargin(0.)
+        pad1.SetRightMargin(0.)
+        pad1.SetTopMargin(0.0)
+        pad1.SetBottomMargin(0.)
+        pad1.SetTicks(0,1)
+        pad1.Draw()
+        pad1.cd()
+
+        # Draw blank histos
+        blankname = 'myBlankHisto_{}_{}'.format(pad, R)
+        xmax = self.h.GetXaxis().GetBinUpEdge(self.h.GetXaxis().GetNbins())
+        myBlankHisto = ROOT.TH1F(blankname,blankname, 1, self.xmin, xmax)
+        myBlankHisto.SetNdivisions(505)
+        if groomed:
+            myBlankHisto.SetYTitle(self.ytitle_groomed)
+        else:
+            myBlankHisto.SetYTitle(self.ytitle)    
+        myBlankHisto.GetYaxis().SetTitleSize(0.1)
+        myBlankHisto.GetYaxis().SetTitleOffset(1.4)
+        myBlankHisto.GetYaxis().SetLabelSize(0.06)
+        myBlankHisto.SetMinimum(0.001)
+        myBlankHisto.SetMaximum(self.ymax)
+        myBlankHisto.Draw()
+        self.blank_histo_list.append(myBlankHisto)
+
+        scale_factor = 1.
+        if pad in [1]:
+            shift = 0.0
+            shift2 = 0.0
+        else:
+            shift = -0.08
+            shift2 = -0.08 - shift
+        
+        leg = ROOT.TLegend(0.2+shift,0.96-0.072*scale_factor*4,0.6,0.96)
+        self.setupLegend(leg,0.07)
+        self.plot_list.append(leg)
+
+        leg3 = ROOT.TLegend(0.2+shift,0.95-0.072*scale_factor*2,0.55,0.95)
+        if pad == 3:
+            self.setupLegend(leg3,0.07)
+            self.plot_list.append(leg3)
+            
+        line_lambda_np = ROOT.TLine(self.lambda_np[R], 0, self.lambda_np[R], self.ymax*0.6)
+        line_lambda_np.SetLineColor(self.colors[-1])
+        line_lambda_np.SetLineStyle(2)
+        line_lambda_np.SetLineWidth(2)
+        self.plot_list.append(line_lambda_np)
+
+        # Draw data
+        self.h.SetMarkerColor(self.color_data)
+        self.h.SetLineColor(self.color_data)
+        self.h.SetLineWidth(2)
+        self.h.SetMarkerStyle(self.marker_data)
+        self.h.SetMarkerSize(self.marker_size)
+
+        self.h_sys.SetLineColor(0)
+        self.h_sys.SetMarkerSize(0)
+        self.h_sys.SetMarkerColor(0)
+        self.h_sys.SetFillColor(self.color_data)
+        self.h_sys.SetFillColorAlpha(self.color_data, 0.3)
+        self.h_sys.SetFillStyle(1001)
+        self.h_sys.SetLineWidth(0)
+        
+        leg.AddEntry(self.h,'ALICE','PE')
+        
+        # Draw theory
+        for i,folding_label in enumerate(self.folding_labels):
+        
+            self.g_theory_dict[beta][i].SetFillColorAlpha(self.colors[i], 0.25)
+            self.g_theory_dict[beta][i].SetLineColor(self.colors[i])
+            self.g_theory_dict[beta][i].SetLineWidth(3)
+            self.g_theory_dict[beta][i].Draw('L 3 same')
+            
+            leg.AddEntry(self.g_theory_dict[beta][i],'NLO+NLL #otimes {}'.format(folding_label),'lf')
+            
+        self.h_sys.Draw('E2 same')
+        line_lambda_np.Draw()
+        self.h.Draw('PE X0 same')
+
+        if pad == 2:
+            leg.Draw('same')
+        if pad == 3:
+            leg3.Draw('same')
+        
+        if pad == 3:
+            leg3.AddEntry(line_lambda_np, '#it{#lambda}_{#it{#beta}}^{NP} #leq #Lambda / (#it{p}_{T,jet}^{ch} #it{R})', 'lf')
+            leg3.AddEntry(self.h_sys, 'Sys. uncertainty', 'f')
+
+        # # # # # # # # # # # # # # # # # # # # # # # #
+        # text
+        # # # # # # # # # # # # # # # # # # # # # # # #
+        ymax = 0.93
+        dy = 0.07
+        x = 0.45 + shift + shift2
+        size = 0.06
+    
+        if pad == 1:
+            system0 = ROOT.TLatex(x,ymax,'ALICE')
+            system0.SetNDC()
+            system0.SetTextSize(size*scale_factor)
+            system0.Draw()
+
+            system1 = ROOT.TLatex(x,ymax-dy,'pp  #sqrt{#it{s}} = 5.02 TeV')
+            system1.SetNDC()
+            system1.SetTextSize(size*scale_factor)
+            system1.Draw()
+
+            system2 = ROOT.TLatex(x,ymax-2*dy,'charged jets   anti-#it{k}_{T}')
+            system2.SetNDC()
+            system2.SetTextSize(size*scale_factor)
+            system2.Draw()
+
+            system3 = ROOT.TLatex(x,ymax-3*dy, '#it{{R}} = {}    | #it{{#eta}}_{{jet}}| < {}'.format(R, 0.9-R))
+            system3.SetNDC()
+            system3.SetTextSize(size*scale_factor)
+            system3.Draw()
+            
+            system4 = ROOT.TLatex(x,ymax-4.*dy-0.02, str(self.min_pt) + ' < #it{p}_{T,jet}^{ch} < ' + str(self.max_pt) + ' GeV/#it{c}')
+            system4.SetNDC()
+            system4.SetTextSize(size*scale_factor)
+            system4.Draw()
+
+            self.plot_list.append(system0)
+            self.plot_list.append(system1)
+            self.plot_list.append(system2)
+            self.plot_list.append(system3)
+            self.plot_list.append(system4)
+            
+        system5 = ROOT.TLatex(x+0.2,ymax-6.*dy, '#it{{#beta}} = {}{}'.format(beta,self.scale_label))
+        system5.SetNDC()
+        if pad in [1]:
+            beta_size = size
+        else:
+            beta_size = 1.3*size
+        system5.SetTextSize(beta_size)
+        system5.Draw()
+        self.plot_list.append(system5)
+
+        if groomed and pad == 1:
+            system5 = ROOT.TLatex(x, ymax-4.2*dy, 'Soft Drop #it{z}_{cut} = 0.2 #beta_{SD} = 0')
+            system5.SetNDC()
+            system5.SetTextSize(size*scale_factor)
+            system5.Draw()
+            self.plot_list.append(system5)
+
+        # Set pad for ratio
+        c.cd(pad)
+        pad2 = ROOT.TPad("pad2_{}".format(R), "pad2{}".format(R),0,0,1,self.bottom_offset+self.ratio_height)
+        self.plot_list.append(pad2)
+        if pad in [1]:
+            pad2.SetLeftMargin(self.left_offset)
+        else:
+            pad2.SetLeftMargin(0.)
+        pad2.SetRightMargin(0.)
+        pad2.SetTopMargin(0.)
+        pad2.SetBottomMargin(self.bottom_offset/(self.bottom_offset+self.ratio_height))
+        pad2.SetTicks(1,1)
+        pad2.SetLogy()
+        pad2.Draw()
+        pad2.cd()
+
+        # Draw blank histos
+        blankname = 'myBlankHisto2_{}_{}'.format(pad, R)
+        myBlankHisto2 = ROOT.TH1F(blankname,blankname, 1, self.xmin, xmax-0.001)
+        myBlankHisto2.SetNdivisions(505, "y")
+        myBlankHisto2.SetNdivisions(505, "x")
+        if groomed:
+            myBlankHisto2.SetXTitle(self.xtitle_groomed)
+        else:
+            myBlankHisto2.SetXTitle(self.xtitle)
+        myBlankHisto2.SetYTitle('#frac{Data}{Theory}')
+        myBlankHisto2.GetXaxis().SetTitleSize(0.15)
+        myBlankHisto2.GetXaxis().SetTitleOffset(1.)
+        myBlankHisto2.GetXaxis().SetLabelSize(0.1)
+        myBlankHisto2.GetYaxis().SetTitleSize(0.12)
+        myBlankHisto2.GetYaxis().SetTitleOffset(1.)
+        myBlankHisto2.GetYaxis().SetLabelSize(0.1)
+        myBlankHisto2.SetMinimum(self.ymin_ratio)
+        myBlankHisto2.SetMaximum(self.ymax_ratio)
+        myBlankHisto2.Draw()
+        self.blank_histo_list.append(myBlankHisto2)
+
+        line = ROOT.TLine(self.xmin,1,xmax,1)
+        line.SetLineColor(1)
+        line.SetLineStyle(2)
+        line.Draw('same')
+        self.plot_list.append(line)
+
+        # Draw ratio
+        for i,folding_label in enumerate(self.folding_labels):
+        
+            # Draw tgraph with sys uncertainty
+            self.g_ratio_dict[beta][i].SetFillColorAlpha(self.colors[i], 0.25)
+            self.g_ratio_dict[beta][i].SetLineColor(self.colors[i])
+            self.g_ratio_dict[beta][i].SetLineWidth(3)
+            self.g_ratio_dict[beta][i].Draw('3 same')
+        
+            # Draw th1 with stat uncertainty
+            self.h_ratio_dict[beta][i].SetMarkerColorAlpha(self.colors[i], self.alpha)
+            self.h_ratio_dict[beta][i].SetLineColorAlpha(self.colors[i], self.alpha)
+            self.h_ratio_dict[beta][i].SetFillColorAlpha(self.colors[i], self.alpha)
+            self.h_ratio_dict[beta][i].SetLineColor(self.colors[i])
+            self.h_ratio_dict[beta][i].SetLineWidth(2)
+            self.h_ratio_dict[beta][i].SetMarkerStyle(self.markers[i])
+            self.h_ratio_dict[beta][i].SetMarkerSize(self.marker_size)
+            self.h_ratio_dict[beta][i].Draw('PE same')
+            
+        line_lambda_np_ratio = ROOT.TLine(self.lambda_np[R], self.ymin_ratio, self.lambda_np[R], self.ymax_ratio)
+        line_lambda_np_ratio.SetLineColor(self.colors[-1])
+        line_lambda_np_ratio.SetLineStyle(2)
+        line_lambda_np_ratio.SetLineWidth(2)
+        line_lambda_np_ratio.Draw()
+        self.plot_list.append(line_lambda_np_ratio)
+
+    #-------------------------------------------------------------------------------------------
+    # Construct ratio data/theory as TGraph
+    # Fills:
+    #   - self.h_ratio_list with histogram of ratio with stat uncertainties
+    #   - self.g_theory_dict with tgraph of ratio with sys uncertainties
+    #-------------------------------------------------------------------------------------------
+    def construct_ratio(self, h, h_sys, h_theory_cent, h_theory_min, h_theory_max, n, x, xerrup, xerrdn, y, yerrup, yerrdn, R, beta, i, pad):
+
+        # Construct central value
+        h_ratio = h.Clone()
+        h_ratio.SetName('{}_{}_{}_{}'.format(h_ratio.GetName(), R, beta, pad))
+        h_ratio.SetDirectory(0)
+        h_ratio.Divide(h_theory_cent)
+        self.plot_list.append(h_ratio)
+        self.h_ratio_dict[beta].append(h_ratio)
+        y_ratio = np.array([h_ratio.GetBinContent(i) for i in range(1, n+1)])
+        
+        # Construct systematic uncertainties: combine data and theory uncertainties
+        
+        # Get relative systematic from data
+        y_data = np.array([h.GetBinContent(i) for i in range(1, n+1)])
+        y_sys_data = np.array([h_sys.GetBinError(i) for i in range(1, n+1)])
+        y_sys_data_relative = np.divide(y_sys_data, y_data)
+        
+        # Get relative systematics from theory
+        yerr_up_relative = np.divide(yerrup, y)
+        yerr_dn_relative = np.divide(yerrdn, y)
+        
+        # Combine systematics in quadrature
+        y_sys_total_up_relative = np.sqrt( np.square(y_sys_data_relative) + np.square(yerr_up_relative))
+        y_sys_total_dn_relative = np.sqrt( np.square(y_sys_data_relative) + np.square(yerr_dn_relative))
+        
+        y_sys_total_up = np.multiply(y_sys_total_up_relative, y_ratio)
+        y_sys_total_dn = np.multiply(y_sys_total_dn_relative, y_ratio)
+        
+        # Note: invert direction of asymmetric uncertainty
+        g_ratio = ROOT.TGraphAsymmErrors(n, x, y_ratio, xerrdn, xerrup, y_sys_total_up, y_sys_total_dn)
+        g_ratio.SetName('g_ratio_{}_{}'.format(i, beta))
+        self.g_ratio_dict[beta].append(g_ratio)
+        
+    #-------------------------------------------------------------------------------------------
+    # Rebin theory histogram according to data binning
+    # Set statistical uncertainties to 0 (since we will neglect them)
+    #-------------------------------------------------------------------------------------------
+    def rebin_theory(self, h_theory, h):
+    
+        n = h.GetNbinsX()
+        bins = []
+        for bi in range(1, n+2):
+            bins.append(h.GetBinLowEdge(bi))
+        xbins = array('d', bins)
+
+        for bi in range(1, h_theory.GetNbinsX()+2):
+            # Undo scaling by bin width before rebinning
+            h_theory.SetBinContent(bi, h_theory.GetBinContent(bi) * h_theory.GetBinWidth(bi))
+
+        h_theory_rebinned = h_theory.Rebin(n, '{}_rebinned'.format(h_theory.GetName()), xbins)
+        h_theory_rebinned.SetDirectory(0)
+        h_theory_rebinned.Scale(1., 'width')
+        
+        for bin in range(1, n+2):
+            h_theory_rebinned.SetBinError(bin, 0)
+    
+        return h_theory_rebinned
+
+    #-------------------------------------------------------------------------------------------
+    # Scale vertical amplitude of histogram, for visualization
+    #-------------------------------------------------------------------------------------------
+    def scale_histogram_for_visualization(self, h, beta, groomed):
+
+        scale_factor = 1.
+        if groomed:
+            if beta == '1.5':
+                scale_factor = self.scale_factor_groomed_beta15
+            if beta == '2':
+                scale_factor = self.scale_factor_groomed_beta2
+            if beta == '3':
+                scale_factor = self.scale_factor_groomed_beta3       
+        else:
+            if beta == '2':
+                scale_factor = self.scale_factor_ungroomed_beta2
+            if beta == '3':
+                scale_factor = self.scale_factor_ungroomed_beta3
+
+        h.Scale(scale_factor)
+
+        if math.isclose(scale_factor, 1.):
+            plot_label = ''
+        else:
+            plot_label = ' (#times{})'.format(scale_factor)
+        
+        return plot_label
+
+    #-------------------------------------------------------------------------------------------
+    # Set legend parameters
+    #-------------------------------------------------------------------------------------------
+    def setupLegend(self, leg, textSize):
+
+        leg.SetTextFont(42);
+        leg.SetBorderSize(0);
+        leg.SetFillStyle(0);
+        leg.SetFillColor(0);
+        leg.SetMargin(0.25);
+        leg.SetTextSize(textSize);
+        leg.SetEntrySeparation(0.5);
+
+    #---------------------------------------------------------------
+    # Remove periods from a label
+    #---------------------------------------------------------------
+    def remove_periods(self, text):
+
+        string = str(text)
+        return string.replace('.', '')
+
+    #-------------------------------------------------------------------------------------------
+    def setOptions(self):
+
+        font = 42
+
+        ROOT.gStyle.SetFrameBorderMode(0)
+        ROOT.gStyle.SetFrameFillColor(0)
+        ROOT.gStyle.SetCanvasBorderMode(0)
+        ROOT.gStyle.SetPadBorderMode(0)
+        ROOT.gStyle.SetPadColor(10)
+        ROOT.gStyle.SetCanvasColor(10)
+        ROOT.gStyle.SetTitleFillColor(10)
+        ROOT.gStyle.SetTitleBorderSize(1)
+        ROOT.gStyle.SetStatColor(10)
+        ROOT.gStyle.SetStatBorderSize(1)
+        ROOT.gStyle.SetLegendBorderSize(1)
+
+        ROOT.gStyle.SetDrawBorder(0)
+        ROOT.gStyle.SetTextFont(font)
+        ROOT.gStyle.SetStatFont(font)
+        ROOT.gStyle.SetStatFontSize(0.05)
+        ROOT.gStyle.SetStatX(0.97)
+        ROOT.gStyle.SetStatY(0.98)
+        ROOT.gStyle.SetStatH(0.03)
+        ROOT.gStyle.SetStatW(0.3)
+        ROOT.gStyle.SetTickLength(0.02,"y")
+        ROOT.gStyle.SetEndErrorSize(3)
+        ROOT.gStyle.SetLabelSize(0.05,"xyz")
+        ROOT.gStyle.SetLabelFont(font,"xyz")
+        ROOT.gStyle.SetLabelOffset(0.01,"xyz")
+        ROOT.gStyle.SetTitleFont(font,"xyz")
+        ROOT.gStyle.SetTitleOffset(1.2,"xyz")
+        ROOT.gStyle.SetTitleSize(0.045,"xyz")
+        ROOT.gStyle.SetMarkerSize(1)
+        ROOT.gStyle.SetPalette(1)
+
+        ROOT.gStyle.SetOptTitle(0)
+        ROOT.gStyle.SetOptStat(0)
+        ROOT.gStyle.SetOptFit(0)
+
+#-------------------------------------------------------------------------------------------
+#-------------------------------------------------------------------------------------------
+#-------------------------------------------------------------------------------------------
+if __name__ == '__main__':
+    print('Executing plot_angularity.py...')
+    print('')
+
+    # Define arguments
+    parser = argparse.ArgumentParser(description='Plot angularity')
+    parser.add_argument(
+        '-o',
+        '--outputDir',
+        action='store',
+        type=str,
+        metavar='outputDir',
+        default='.',
+        help='Output directory for output to be written to'
+    )
+
+    # Parse the arguments
+    args = parser.parse_args()
+
+    analysis = PlotAngularityFigures(output_dir=args.outputDir)
+    analysis.plot_results()

--- a/pyjetty/alice_analysis/analysis/user/ang_pp/plot_angularity_theory_figures.py
+++ b/pyjetty/alice_analysis/analysis/user/ang_pp/plot_angularity_theory_figures.py
@@ -213,7 +213,9 @@ class PlotAngularityFigures(common_base.CommonBase):
 
             beta_label = beta
             if beta == '1.5':
-                beta_label = 15
+                beta_label = '15'
+            if groomed:
+                beta_label += '_SD_zcut02_B0'
             name_cent = 'theory_cent_ang_R{}_{}_ch_PtBin60-80_{}'.format(
                 self.remove_periods(str(R)), beta_label, i)
             name_min = 'theory_min_ang_R{}_{}_ch_PtBin60-80_{}'.format(

--- a/pyjetty/alice_analysis/analysis/user/ang_pp/run_analysis_ang.py
+++ b/pyjetty/alice_analysis/analysis/user/ang_pp/run_analysis_ang.py
@@ -230,39 +230,40 @@ class RunAnalysisAng(run_analysis.RunAnalysis):
 
     if 'theory_dir' in config:
       self.do_theory = config['do_theory_comp']
+      if self.do_theory:
 
-      self.theory_dir = config['theory_dir']
-      self.theory_beta = config['theory_beta']
-      self.theory_pt_bins = config['theory_pt_bins']
-      self.theory_response_files = [ROOT.TFile(f, 'READ') for f in config['response_files']]
-      self.theory_response_labels = config['response_labels']
-      self.theory_pt_scale_factors_filepath = os.path.join(
-        self.theory_dir, config['pt_scale_factors_filename'])
-      self.rebin_theory_response = config['rebin_theory_response']
-      self.output_dir_theory = os.path.join(self.output_dir, self.observable, 'theory_response')
-      self.Lambda = 1  # GeV -- This variable changes the NP vs P region of theory plots
+        self.theory_dir = config['theory_dir']
+        self.theory_beta = config['theory_beta']
+        self.theory_pt_bins = config['theory_pt_bins']
+        self.theory_response_files = [ROOT.TFile(f, 'READ') for f in config['response_files']]
+        self.theory_response_labels = config['response_labels']
+        self.theory_pt_scale_factors_filepath = os.path.join(
+          self.theory_dir, config['pt_scale_factors_filename'])
+        self.rebin_theory_response = config['rebin_theory_response']
+        self.output_dir_theory = os.path.join(self.output_dir, self.observable, 'theory_response')
+        self.Lambda = 1  # GeV -- This variable changes the NP vs P region of theory plots
 
-      self.do_theory_F_np = False  # NP shape f'n convolution
-      if self.do_theory_F_np:
-        self.Omega_list = config['Omega_list']  # list of universal(?) parameters to try
+        self.do_theory_F_np = False  # NP shape f'n convolution
+        if self.do_theory_F_np:
+          self.Omega_list = config['Omega_list']  # list of universal(?) parameters to try
 
-      # Define observable binnings -- may want to move to config file eventually
-      self.theory_obs_bins = np.concatenate((
-        np.linspace(0, 0.009, 10), np.linspace(0.01, 0.1, 19), np.linspace(0.11, 0.8, 70)))
-      self.theory_obs_bins_center = np.concatenate(
-        (np.linspace(0.0005, 0.0095, 10), np.linspace(0.0125, 0.0975, 18),
-         np.linspace(0.105, 0.795, 70)))
-      self.theory_obs_bins_width = 10 * [0.001] + 18 * [0.005] + 70 * [0.01]
+        # Define observable binnings -- may want to move to config file eventually
+        self.theory_obs_bins = np.concatenate((
+          np.linspace(0, 0.009, 10), np.linspace(0.01, 0.1, 19), np.linspace(0.11, 0.8, 70)))
+        self.theory_obs_bins_center = np.concatenate(
+          (np.linspace(0.0005, 0.0095, 10), np.linspace(0.0125, 0.0975, 18),
+           np.linspace(0.105, 0.795, 70)))
+        self.theory_obs_bins_width = 10 * [0.001] + 18 * [0.005] + 70 * [0.01]
 
-      # Use the old theory prediction binnings as test (ungroomed only)
-      self.use_old = False
-      if self.use_old:
-        self.theory_grooming_settings = []
-        self.theory_grooming_labels = []
-        self.theory_pt_bins = list(range(10, 160, 10))
-        #self.theory_obs_bins = np.linspace(0, 0.8, 81)
-        #self.theory_obs_bins_center = np.linspace(0.005, 0.795, 80)
-        #self.theory_obs_bins_width = 80 * [0.01]
+        # Use the old theory prediction binnings as test (ungroomed only)
+        self.use_old = False
+        if self.use_old:
+          self.theory_grooming_settings = []
+          self.theory_grooming_labels = []
+          self.theory_pt_bins = list(range(10, 160, 10))
+          #self.theory_obs_bins = np.linspace(0, 0.8, 81)
+          #self.theory_obs_bins_center = np.linspace(0.005, 0.795, 80)
+          #self.theory_obs_bins_width = 80 * [0.01]
 
     else:
       self.do_theory = False

--- a/pyjetty/alice_analysis/config/ang/angularity_R0.2_ptbin1.yaml
+++ b/pyjetty/alice_analysis/config/ang/angularity_R0.2_ptbin1.yaml
@@ -186,11 +186,11 @@ ang:
 do_theory_comp: True
 theory_beta: [1.5, 2, 3]
 theory_dir: "/home/ezra/ALICE_table/"
-theory_pt_bins: [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150]
-response_files: ["/rstorage/alice/AnalysisResults/ang/196181/AnalysisResultsFinal.root",
-                 "/rstorage/alice/AnalysisResults/ang/286620/AnalysisResultsFinal.root",
-                 "/rstorage/alice/AnalysisResults/ang/225271/AnalysisResultsFinal.root"]
-response_labels: ["PYTHIA8", "P8time", "Herwig7"]
+theory_pt_bins: [10, 15, 20, 25, 30, 35, 40, 45, 50, 60, 70, 80, 90, 100,
+                 110, 120, 130, 140, 150, 160, 170, 180, 190, 200]
+response_files: ["/rstorage/alice/AnalysisResults/ang/344810/AnalysisResultsFinal.root",
+                 "/rstorage/alice/AnalysisResults/ang/344912/AnalysisResultsFinal.root"]
+response_labels: ["PYTHIA8", "Herwig7"]
 rebin_theory_response: False
 
 

--- a/pyjetty/alice_analysis/config/ang/angularity_R0.2_ptbin1.yaml
+++ b/pyjetty/alice_analysis/config/ang/angularity_R0.2_ptbin1.yaml
@@ -189,7 +189,8 @@ theory_dir: "/home/ezra/theory_predictions/"
 pt_scale_factors_filename: "qg_fractions-ALICE-R04.txt"
 theory_pt_bins: [10, 15, 20, 25, 30, 35, 40, 45, 50, 60, 70, 80, 90, 100,
                  110, 120, 130, 140, 150, 160, 170, 180, 190, 200]
-response_files: ["/rstorage/alice/AnalysisResults/ang/344810/AnalysisResultsFinal.root",
+Omega_list: [0.1, 0.3, 0.8]
+response_files: ["/rstorage/alice/AnalysisResults/ang/353823/AnalysisResultsFinal.root",
                  "/rstorage/alice/AnalysisResults/ang/344912/AnalysisResultsFinal.root"]
 response_labels: ["PYTHIA8", "Herwig7"]
 rebin_theory_response: False

--- a/pyjetty/alice_analysis/config/ang/angularity_R0.2_ptbin1.yaml
+++ b/pyjetty/alice_analysis/config/ang/angularity_R0.2_ptbin1.yaml
@@ -185,7 +185,8 @@ ang:
 # Theory comparison parameters
 do_theory_comp: True
 theory_beta: [1.5, 2, 3]
-theory_dir: "/home/ezra/ALICE_table/"
+theory_dir: "/home/ezra/theory_predictions/"
+pt_scale_factors_filename: "qg_fractions-ALICE-R04.txt"
 theory_pt_bins: [10, 15, 20, 25, 30, 35, 40, 45, 50, 60, 70, 80, 90, 100,
                  110, 120, 130, 140, 150, 160, 170, 180, 190, 200]
 response_files: ["/rstorage/alice/AnalysisResults/ang/344810/AnalysisResultsFinal.root",
@@ -227,10 +228,10 @@ systematics_list:
 
 # Paths to processing output, to be used for unfolding
 main_data: '/rstorage/alice/AnalysisResults/ang/287220/AnalysisResultsFinal.root'
-main_response: '/rstorage/alice/AnalysisResults/ang/287381/AnalysisResultsFinal.root'
-trkeff_response: '/rstorage/alice/AnalysisResults/ang/287382/AnalysisResultsFinal.root'
+main_response: '/rstorage/alice/AnalysisResults/ang/351487/AnalysisResultsFinal.root'
+trkeff_response: '/rstorage/alice/AnalysisResults/ang/351489/AnalysisResultsFinal.root'
 randmass_data: '/rstorage/alice/AnalysisResults/ang/287383/AnalysisResultsFinal.root'
-randmass_response: '/rstorage/alice/AnalysisResults/ang/287384/AnalysisResultsFinal.root'
+randmass_response: '/rstorage/alice/AnalysisResults/ang/351488/AnalysisResultsFinal.root'
 fastsim_response: ['/rstorage/alice/AnalysisResults/ang/287385/AnalysisResultsFinal.root',
                    '/rstorage/alice/AnalysisResults/ang/287386/AnalysisResultsFinal.root']
 

--- a/pyjetty/alice_analysis/config/ang/angularity_R0.2_ptbin1.yaml
+++ b/pyjetty/alice_analysis/config/ang/angularity_R0.2_ptbin1.yaml
@@ -198,7 +198,7 @@ rebin_theory_response: False
 # Analysis & plotting parameters
 file_format: ".pdf"
 output_dir: "/rstorage/alice/AnalysisResults/ang/AngR02_ptbin1"
-roounfold_path: "/home/ezra/heppy/external/roounfold/roounfold-2.0.0/lib/libRooUnfold.so"
+roounfold_path: "/home/ezra/heppy/external/roounfold/roounfold-current/lib/libRooUnfold.so"
 
 analysis_observable: 'ang'
 do_unfolding: False

--- a/pyjetty/alice_analysis/config/ang/angularity_R0.2_ptbin2.yaml
+++ b/pyjetty/alice_analysis/config/ang/angularity_R0.2_ptbin2.yaml
@@ -177,7 +177,7 @@ rebin_theory_response: False
 # Analysis & plotting parameters
 file_format: ".pdf"
 output_dir: "/rstorage/alice/AnalysisResults/ang/AngR02_ptbin2"
-roounfold_path: "$HEPPY_DIR/external/roounfold/roounfold-2.0.0/lib/libRooUnfold.so"
+roounfold_path: "$HEPPY_DIR/external/roounfold/roounfold-current/lib/libRooUnfold.so"
 
 analysis_observable: 'ang'
 do_unfolding: False

--- a/pyjetty/alice_analysis/config/ang/angularity_R0.2_ptbin2.yaml
+++ b/pyjetty/alice_analysis/config/ang/angularity_R0.2_ptbin2.yaml
@@ -168,7 +168,8 @@ theory_dir: "/home/ezra/theory_predictions/"
 pt_scale_factors_filename: "qg_fractions-ALICE-R04.txt"
 theory_pt_bins: [10, 15, 20, 25, 30, 35, 40, 45, 50, 60, 70, 80, 90, 100,
                  110, 120, 130, 140, 150, 160, 170, 180, 190, 200]
-response_files: ["/rstorage/alice/AnalysisResults/ang/344810/AnalysisResultsFinal.root",
+Omega_list: [0.1, 0.3, 0.8]
+response_files: ["/rstorage/alice/AnalysisResults/ang/353823/AnalysisResultsFinal.root",
                  "/rstorage/alice/AnalysisResults/ang/344912/AnalysisResultsFinal.root"]
 response_labels: ["PYTHIA8", "Herwig7"]
 rebin_theory_response: False

--- a/pyjetty/alice_analysis/config/ang/angularity_R0.2_ptbin2.yaml
+++ b/pyjetty/alice_analysis/config/ang/angularity_R0.2_ptbin2.yaml
@@ -164,7 +164,8 @@ ang:
 # Theory comparison parameters
 do_theory_comp: True
 theory_beta: [1.5, 2, 3]
-theory_dir: "/home/ezra/ALICE_table/"
+theory_dir: "/home/ezra/theory_predictions/"
+pt_scale_factors_filename: "qg_fractions-ALICE-R04.txt"
 theory_pt_bins: [10, 15, 20, 25, 30, 35, 40, 45, 50, 60, 70, 80, 90, 100,
                  110, 120, 130, 140, 150, 160, 170, 180, 190, 200]
 response_files: ["/rstorage/alice/AnalysisResults/ang/344810/AnalysisResultsFinal.root",
@@ -206,10 +207,10 @@ systematics_list:
 
 # Paths to processing output, to be used for unfolding
 main_data: '/rstorage/alice/AnalysisResults/ang/287220/AnalysisResultsFinal.root'
-main_response: '/rstorage/alice/AnalysisResults/ang/287381/AnalysisResultsFinal.root'
-trkeff_response: '/rstorage/alice/AnalysisResults/ang/287382/AnalysisResultsFinal.root'
+main_response: '/rstorage/alice/AnalysisResults/ang/351487/AnalysisResultsFinal.root'
+trkeff_response: '/rstorage/alice/AnalysisResults/ang/351489/AnalysisResultsFinal.root'
 randmass_data: '/rstorage/alice/AnalysisResults/ang/287383/AnalysisResultsFinal.root'
-randmass_response: '/rstorage/alice/AnalysisResults/ang/287384/AnalysisResultsFinal.root'
+randmass_response: '/rstorage/alice/AnalysisResults/ang/351488/AnalysisResultsFinal.root'
 fastsim_response: ['/rstorage/alice/AnalysisResults/ang/287385/AnalysisResultsFinal.root',
                    '/rstorage/alice/AnalysisResults/ang/287386/AnalysisResultsFinal.root']
 

--- a/pyjetty/alice_analysis/config/ang/angularity_R0.2_ptbin2.yaml
+++ b/pyjetty/alice_analysis/config/ang/angularity_R0.2_ptbin2.yaml
@@ -165,11 +165,11 @@ ang:
 do_theory_comp: True
 theory_beta: [1.5, 2, 3]
 theory_dir: "/home/ezra/ALICE_table/"
-theory_pt_bins: [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150]
-response_files: ["/rstorage/alice/AnalysisResults/ang/196181/AnalysisResultsFinal.root",
-                 "/rstorage/alice/AnalysisResults/ang/286620/AnalysisResultsFinal.root",
-                 "/rstorage/alice/AnalysisResults/ang/225271/AnalysisResultsFinal.root"]
-response_labels: ["PYTHIA8", "P8time", "Herwig7"]
+theory_pt_bins: [10, 15, 20, 25, 30, 35, 40, 45, 50, 60, 70, 80, 90, 100,
+                 110, 120, 130, 140, 150, 160, 170, 180, 190, 200]
+response_files: ["/rstorage/alice/AnalysisResults/ang/344810/AnalysisResultsFinal.root",
+                 "/rstorage/alice/AnalysisResults/ang/344912/AnalysisResultsFinal.root"]
+response_labels: ["PYTHIA8", "Herwig7"]
 rebin_theory_response: False
 
 

--- a/pyjetty/alice_analysis/config/ang/angularity_R0.2_ptbin3.yaml
+++ b/pyjetty/alice_analysis/config/ang/angularity_R0.2_ptbin3.yaml
@@ -173,7 +173,7 @@ rebin_theory_response: False
 # Analysis & plotting parameters
 file_format: ".pdf"
 output_dir: "/rstorage/alice/AnalysisResults/ang/AngR02_ptbin3"
-roounfold_path: "/home/ezra/heppy/external/roounfold/roounfold-2.0.0/lib/libRooUnfold.so"
+roounfold_path: "/home/ezra/heppy/external/roounfold/roounfold-current/lib/libRooUnfold.so"
 
 analysis_observable: 'ang'
 do_unfolding: False

--- a/pyjetty/alice_analysis/config/ang/angularity_R0.2_ptbin3.yaml
+++ b/pyjetty/alice_analysis/config/ang/angularity_R0.2_ptbin3.yaml
@@ -164,7 +164,8 @@ theory_dir: "/home/ezra/theory_predictions/"
 pt_scale_factors_filename: "qg_fractions-ALICE-R04.txt"
 theory_pt_bins: [10, 15, 20, 25, 30, 35, 40, 45, 50, 60, 70, 80, 90, 100,
                  110, 120, 130, 140, 150, 160, 170, 180, 190, 200]
-response_files: ["/rstorage/alice/AnalysisResults/ang/344810/AnalysisResultsFinal.root",
+Omega_list: [0.1, 0.3, 0.8]
+response_files: ["/rstorage/alice/AnalysisResults/ang/353823/AnalysisResultsFinal.root",
                  "/rstorage/alice/AnalysisResults/ang/344912/AnalysisResultsFinal.root"]
 response_labels: ["PYTHIA8", "Herwig7"]
 rebin_theory_response: False

--- a/pyjetty/alice_analysis/config/ang/angularity_R0.2_ptbin3.yaml
+++ b/pyjetty/alice_analysis/config/ang/angularity_R0.2_ptbin3.yaml
@@ -161,11 +161,11 @@ ang:
 do_theory_comp: True
 theory_beta: [1.5, 2, 3]
 theory_dir: "/home/ezra/ALICE_table/"
-theory_pt_bins: [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150]
-response_files: ["/rstorage/alice/AnalysisResults/ang/196181/AnalysisResultsFinal.root",
-                 "/rstorage/alice/AnalysisResults/ang/286620/AnalysisResultsFinal.root",
-                 "/rstorage/alice/AnalysisResults/ang/225271/AnalysisResultsFinal.root"]
-response_labels: ["PYTHIA8", "P8time", "Herwig7"]
+theory_pt_bins: [10, 15, 20, 25, 30, 35, 40, 45, 50, 60, 70, 80, 90, 100,
+                 110, 120, 130, 140, 150, 160, 170, 180, 190, 200]
+response_files: ["/rstorage/alice/AnalysisResults/ang/344810/AnalysisResultsFinal.root",
+                 "/rstorage/alice/AnalysisResults/ang/344912/AnalysisResultsFinal.root"]
+response_labels: ["PYTHIA8", "Herwig7"]
 rebin_theory_response: False
 
 

--- a/pyjetty/alice_analysis/config/ang/angularity_R0.2_ptbin3.yaml
+++ b/pyjetty/alice_analysis/config/ang/angularity_R0.2_ptbin3.yaml
@@ -160,7 +160,8 @@ ang:
 # Theory comparison parameters
 do_theory_comp: True
 theory_beta: [1.5, 2, 3]
-theory_dir: "/home/ezra/ALICE_table/"
+theory_dir: "/home/ezra/theory_predictions/"
+pt_scale_factors_filename: "qg_fractions-ALICE-R04.txt"
 theory_pt_bins: [10, 15, 20, 25, 30, 35, 40, 45, 50, 60, 70, 80, 90, 100,
                  110, 120, 130, 140, 150, 160, 170, 180, 190, 200]
 response_files: ["/rstorage/alice/AnalysisResults/ang/344810/AnalysisResultsFinal.root",
@@ -202,10 +203,10 @@ systematics_list:
 
 # Paths to processing output, to be used for unfolding
 main_data: '/rstorage/alice/AnalysisResults/ang/287220/AnalysisResultsFinal.root'
-main_response: '/rstorage/alice/AnalysisResults/ang/287381/AnalysisResultsFinal.root'
-trkeff_response: '/rstorage/alice/AnalysisResults/ang/287382/AnalysisResultsFinal.root'
+main_response: '/rstorage/alice/AnalysisResults/ang/351487/AnalysisResultsFinal.root'
+trkeff_response: '/rstorage/alice/AnalysisResults/ang/351489/AnalysisResultsFinal.root'
 randmass_data: '/rstorage/alice/AnalysisResults/ang/287383/AnalysisResultsFinal.root'
-randmass_response: '/rstorage/alice/AnalysisResults/ang/287384/AnalysisResultsFinal.root'
+randmass_response: '/rstorage/alice/AnalysisResults/ang/351488/AnalysisResultsFinal.root'
 fastsim_response: ['/rstorage/alice/AnalysisResults/ang/287385/AnalysisResultsFinal.root',
                    '/rstorage/alice/AnalysisResults/ang/287386/AnalysisResultsFinal.root']
 

--- a/pyjetty/alice_analysis/config/ang/angularity_R0.2_ptbin4.yaml
+++ b/pyjetty/alice_analysis/config/ang/angularity_R0.2_ptbin4.yaml
@@ -164,7 +164,8 @@ theory_dir: "/home/ezra/theory_predictions/"
 pt_scale_factors_filename: "qg_fractions-ALICE-R04.txt"
 theory_pt_bins: [10, 15, 20, 25, 30, 35, 40, 45, 50, 60, 70, 80, 90, 100,
                  110, 120, 130, 140, 150, 160, 170, 180, 190, 200]
-response_files: ["/rstorage/alice/AnalysisResults/ang/344810/AnalysisResultsFinal.root",
+Omega_list: [0.1, 0.3, 0.8]
+response_files: ["/rstorage/alice/AnalysisResults/ang/353823/AnalysisResultsFinal.root",
                  "/rstorage/alice/AnalysisResults/ang/344912/AnalysisResultsFinal.root"]
 response_labels: ["PYTHIA8", "Herwig7"]
 rebin_theory_response: False

--- a/pyjetty/alice_analysis/config/ang/angularity_R0.2_ptbin4.yaml
+++ b/pyjetty/alice_analysis/config/ang/angularity_R0.2_ptbin4.yaml
@@ -161,11 +161,11 @@ ang:
 do_theory_comp: True
 theory_beta: [1.5, 2, 3]
 theory_dir: "/home/ezra/ALICE_table/"
-theory_pt_bins: [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150]
-response_files: ["/rstorage/alice/AnalysisResults/ang/196181/AnalysisResultsFinal.root",
-                 "/rstorage/alice/AnalysisResults/ang/286620/AnalysisResultsFinal.root",
-                 "/rstorage/alice/AnalysisResults/ang/225271/AnalysisResultsFinal.root"]
-response_labels: ["PYTHIA8", "P8time", "Herwig7"]
+theory_pt_bins: [10, 15, 20, 25, 30, 35, 40, 45, 50, 60, 70, 80, 90, 100,
+                 110, 120, 130, 140, 150, 160, 170, 180, 190, 200]
+response_files: ["/rstorage/alice/AnalysisResults/ang/344810/AnalysisResultsFinal.root",
+                 "/rstorage/alice/AnalysisResults/ang/344912/AnalysisResultsFinal.root"]
+response_labels: ["PYTHIA8", "Herwig7"]
 rebin_theory_response: False
 
 

--- a/pyjetty/alice_analysis/config/ang/angularity_R0.2_ptbin4.yaml
+++ b/pyjetty/alice_analysis/config/ang/angularity_R0.2_ptbin4.yaml
@@ -173,7 +173,7 @@ rebin_theory_response: False
 # Analysis & plotting parameters
 file_format: ".pdf"
 output_dir: "/rstorage/alice/AnalysisResults/ang/AngR02_ptbin4"
-roounfold_path: "/home/ezra/heppy/external/roounfold/roounfold-2.0.0/lib/libRooUnfold.so"
+roounfold_path: "/home/ezra/heppy/external/roounfold/roounfold-current/lib/libRooUnfold.so"
 
 analysis_observable: 'ang'
 do_unfolding: False

--- a/pyjetty/alice_analysis/config/ang/angularity_R0.2_ptbin4.yaml
+++ b/pyjetty/alice_analysis/config/ang/angularity_R0.2_ptbin4.yaml
@@ -160,7 +160,8 @@ ang:
 # Theory comparison parameters
 do_theory_comp: True
 theory_beta: [1.5, 2, 3]
-theory_dir: "/home/ezra/ALICE_table/"
+theory_dir: "/home/ezra/theory_predictions/"
+pt_scale_factors_filename: "qg_fractions-ALICE-R04.txt"
 theory_pt_bins: [10, 15, 20, 25, 30, 35, 40, 45, 50, 60, 70, 80, 90, 100,
                  110, 120, 130, 140, 150, 160, 170, 180, 190, 200]
 response_files: ["/rstorage/alice/AnalysisResults/ang/344810/AnalysisResultsFinal.root",
@@ -202,10 +203,10 @@ systematics_list:
 
 # Paths to processing output, to be used for unfolding
 main_data: '/rstorage/alice/AnalysisResults/ang/287220/AnalysisResultsFinal.root'
-main_response: '/rstorage/alice/AnalysisResults/ang/287381/AnalysisResultsFinal.root'
-trkeff_response: '/rstorage/alice/AnalysisResults/ang/287382/AnalysisResultsFinal.root'
+main_response: '/rstorage/alice/AnalysisResults/ang/351487/AnalysisResultsFinal.root'
+trkeff_response: '/rstorage/alice/AnalysisResults/ang/351489/AnalysisResultsFinal.root'
 randmass_data: '/rstorage/alice/AnalysisResults/ang/287383/AnalysisResultsFinal.root'
-randmass_response: '/rstorage/alice/AnalysisResults/ang/287384/AnalysisResultsFinal.root'
+randmass_response: '/rstorage/alice/AnalysisResults/ang/351488/AnalysisResultsFinal.root'
 fastsim_response: ['/rstorage/alice/AnalysisResults/ang/287385/AnalysisResultsFinal.root',
                    '/rstorage/alice/AnalysisResults/ang/287386/AnalysisResultsFinal.root']
 

--- a/pyjetty/alice_analysis/config/ang/angularity_R0.4_ptbin1.yaml
+++ b/pyjetty/alice_analysis/config/ang/angularity_R0.4_ptbin1.yaml
@@ -216,7 +216,8 @@ theory_dir: "/home/ezra/theory_predictions/"
 pt_scale_factors_filename: "qg_fractions-ALICE-R04.txt"
 theory_pt_bins: [10, 15, 20, 25, 30, 35, 40, 45, 50, 60, 70, 80, 90, 100,
                  110, 120, 130, 140, 150, 160, 170, 180, 190, 200]
-response_files: ["/rstorage/alice/AnalysisResults/ang/344810/AnalysisResultsFinal.root",
+Omega_list: [0.1, 0.3, 0.8]
+response_files: ["/rstorage/alice/AnalysisResults/ang/353823/AnalysisResultsFinal.root",
                  "/rstorage/alice/AnalysisResults/ang/344912/AnalysisResultsFinal.root"]
 response_labels: ["PYTHIA8", "Herwig7"]
 rebin_theory_response: False

--- a/pyjetty/alice_analysis/config/ang/angularity_R0.4_ptbin1.yaml
+++ b/pyjetty/alice_analysis/config/ang/angularity_R0.4_ptbin1.yaml
@@ -225,7 +225,7 @@ rebin_theory_response: False
 # Analysis & plotting parameters
 file_format: ".pdf"
 output_dir: "/rstorage/alice/AnalysisResults/ang/AngR04_ptbin1"
-roounfold_path: "/home/ezra/heppy/external/roounfold/roounfold-2.0.0/lib/libRooUnfold.so"
+roounfold_path: "/home/ezra/heppy/external/roounfold/roounfold-current/lib/libRooUnfold.so"
 
 analysis_observable: 'ang'
 do_unfolding: False

--- a/pyjetty/alice_analysis/config/ang/angularity_R0.4_ptbin1.yaml
+++ b/pyjetty/alice_analysis/config/ang/angularity_R0.4_ptbin1.yaml
@@ -18,7 +18,7 @@ jet_matching_distance: 0.6        # Match jets with deltaR < jet_matching_distan
 reject_tracks_fraction: 0
 
 # SoftDrop setting (current same for all SD plots)
-sd_zcut: 0.1    # multiplier
+sd_zcut: 0.2    # multiplier
 sd_beta: 0      # exponent on (deltaR / R)
 
 
@@ -212,7 +212,8 @@ ang:
 # Theory comparison parameters
 do_theory_comp: True
 theory_beta: [1.5, 2, 3]
-theory_dir: "/home/ezra/ALICE_table/"
+theory_dir: "/home/ezra/theory_predictions/"
+pt_scale_factors_filename: "qg_fractions-ALICE-R04.txt"
 theory_pt_bins: [10, 15, 20, 25, 30, 35, 40, 45, 50, 60, 70, 80, 90, 100,
                  110, 120, 130, 140, 150, 160, 170, 180, 190, 200]
 response_files: ["/rstorage/alice/AnalysisResults/ang/344810/AnalysisResultsFinal.root",
@@ -254,10 +255,10 @@ systematics_list:
 
 # Paths to processing output, to be used for unfolding
 main_data: '/rstorage/alice/AnalysisResults/ang/287220/AnalysisResultsFinal.root'
-main_response: '/rstorage/alice/AnalysisResults/ang/287381/AnalysisResultsFinal.root'
-trkeff_response: '/rstorage/alice/AnalysisResults/ang/287382/AnalysisResultsFinal.root'
+main_response: '/rstorage/alice/AnalysisResults/ang/351487/AnalysisResultsFinal.root'
+trkeff_response: '/rstorage/alice/AnalysisResults/ang/351489/AnalysisResultsFinal.root'
 randmass_data: '/rstorage/alice/AnalysisResults/ang/287383/AnalysisResultsFinal.root'
-randmass_response: '/rstorage/alice/AnalysisResults/ang/287384/AnalysisResultsFinal.root'
+randmass_response: '/rstorage/alice/AnalysisResults/ang/351488/AnalysisResultsFinal.root'
 fastsim_response: ['/rstorage/alice/AnalysisResults/ang/287385/AnalysisResultsFinal.root',
                    '/rstorage/alice/AnalysisResults/ang/287386/AnalysisResultsFinal.root']
 

--- a/pyjetty/alice_analysis/config/ang/angularity_R0.4_ptbin1.yaml
+++ b/pyjetty/alice_analysis/config/ang/angularity_R0.4_ptbin1.yaml
@@ -213,11 +213,11 @@ ang:
 do_theory_comp: True
 theory_beta: [1.5, 2, 3]
 theory_dir: "/home/ezra/ALICE_table/"
-theory_pt_bins: [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150]
-response_files: ["/rstorage/alice/AnalysisResults/ang/196181/AnalysisResultsFinal.root",
-                 "/rstorage/alice/AnalysisResults/ang/286620/AnalysisResultsFinal.root",
-                 "/rstorage/alice/AnalysisResults/ang/225271/AnalysisResultsFinal.root"]
-response_labels: ["PYTHIA8", "P8time", "Herwig7"]
+theory_pt_bins: [10, 15, 20, 25, 30, 35, 40, 45, 50, 60, 70, 80, 90, 100,
+                 110, 120, 130, 140, 150, 160, 170, 180, 190, 200]
+response_files: ["/rstorage/alice/AnalysisResults/ang/344810/AnalysisResultsFinal.root",
+                 "/rstorage/alice/AnalysisResults/ang/344912/AnalysisResultsFinal.root"]
+response_labels: ["PYTHIA8", "Herwig7"]
 rebin_theory_response: False
 
 

--- a/pyjetty/alice_analysis/config/ang/angularity_R0.4_ptbin2.yaml
+++ b/pyjetty/alice_analysis/config/ang/angularity_R0.4_ptbin2.yaml
@@ -174,7 +174,8 @@ theory_dir: "/home/ezra/theory_predictions/"
 pt_scale_factors_filename: "qg_fractions-ALICE-R04.txt"
 theory_pt_bins: [10, 15, 20, 25, 30, 35, 40, 45, 50, 60, 70, 80, 90, 100,
                  110, 120, 130, 140, 150, 160, 170, 180, 190, 200]
-response_files: ["/rstorage/alice/AnalysisResults/ang/344810/AnalysisResultsFinal.root",
+Omega_list: [0.1, 0.3, 0.8]
+response_files: ["/rstorage/alice/AnalysisResults/ang/353823/AnalysisResultsFinal.root",
                  "/rstorage/alice/AnalysisResults/ang/344912/AnalysisResultsFinal.root"]
 response_labels: ["PYTHIA8", "Herwig7"]
 rebin_theory_response: False

--- a/pyjetty/alice_analysis/config/ang/angularity_R0.4_ptbin2.yaml
+++ b/pyjetty/alice_analysis/config/ang/angularity_R0.4_ptbin2.yaml
@@ -183,7 +183,7 @@ rebin_theory_response: False
 # Analysis & plotting parameters
 file_format: ".pdf"
 output_dir: "/rstorage/alice/AnalysisResults/ang/AngR04_ptbin2"
-roounfold_path: "/home/ezra/heppy/external/roounfold/roounfold-2.0.0/lib/libRooUnfold.so"
+roounfold_path: "/home/ezra/heppy/external/roounfold/roounfold-current/lib/libRooUnfold.so"
 
 analysis_observable: 'ang'
 do_unfolding: False

--- a/pyjetty/alice_analysis/config/ang/angularity_R0.4_ptbin2.yaml
+++ b/pyjetty/alice_analysis/config/ang/angularity_R0.4_ptbin2.yaml
@@ -18,7 +18,7 @@ jet_matching_distance: 0.6        # Match jets with deltaR < jet_matching_distan
 reject_tracks_fraction: 0
 
 # SoftDrop setting (current same for all SD plots)
-sd_zcut: 0.1    # multiplier
+sd_zcut: 0.2    # multiplier
 sd_beta: 0      # exponent on (deltaR / R)
 
 
@@ -170,7 +170,8 @@ ang:
 # Theory comparison parameters
 do_theory_comp: True
 theory_beta: [1.5, 2, 3]
-theory_dir: "/home/ezra/ALICE_table/"
+theory_dir: "/home/ezra/theory_predictions/"
+pt_scale_factors_filename: "qg_fractions-ALICE-R04.txt"
 theory_pt_bins: [10, 15, 20, 25, 30, 35, 40, 45, 50, 60, 70, 80, 90, 100,
                  110, 120, 130, 140, 150, 160, 170, 180, 190, 200]
 response_files: ["/rstorage/alice/AnalysisResults/ang/344810/AnalysisResultsFinal.root",
@@ -212,10 +213,10 @@ systematics_list:
 
 # Paths to processing output, to be used for unfolding
 main_data: '/rstorage/alice/AnalysisResults/ang/287220/AnalysisResultsFinal.root'
-main_response: '/rstorage/alice/AnalysisResults/ang/287381/AnalysisResultsFinal.root'
-trkeff_response: '/rstorage/alice/AnalysisResults/ang/287382/AnalysisResultsFinal.root'
+main_response: '/rstorage/alice/AnalysisResults/ang/351487/AnalysisResultsFinal.root'
+trkeff_response: '/rstorage/alice/AnalysisResults/ang/351489/AnalysisResultsFinal.root'
 randmass_data: '/rstorage/alice/AnalysisResults/ang/287383/AnalysisResultsFinal.root'
-randmass_response: '/rstorage/alice/AnalysisResults/ang/287384/AnalysisResultsFinal.root'
+randmass_response: '/rstorage/alice/AnalysisResults/ang/351488/AnalysisResultsFinal.root'
 fastsim_response: ['/rstorage/alice/AnalysisResults/ang/287385/AnalysisResultsFinal.root',
                    '/rstorage/alice/AnalysisResults/ang/287386/AnalysisResultsFinal.root']
 

--- a/pyjetty/alice_analysis/config/ang/angularity_R0.4_ptbin2.yaml
+++ b/pyjetty/alice_analysis/config/ang/angularity_R0.4_ptbin2.yaml
@@ -171,11 +171,11 @@ ang:
 do_theory_comp: True
 theory_beta: [1.5, 2, 3]
 theory_dir: "/home/ezra/ALICE_table/"
-theory_pt_bins: [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150]
-response_files: ["/rstorage/alice/AnalysisResults/ang/196181/AnalysisResultsFinal.root",
-                 "/rstorage/alice/AnalysisResults/ang/286620/AnalysisResultsFinal.root",
-                 "/rstorage/alice/AnalysisResults/ang/225271/AnalysisResultsFinal.root"]
-response_labels: ["PYTHIA8", "P8time", "Herwig7"]
+theory_pt_bins: [10, 15, 20, 25, 30, 35, 40, 45, 50, 60, 70, 80, 90, 100,
+                 110, 120, 130, 140, 150, 160, 170, 180, 190, 200]
+response_files: ["/rstorage/alice/AnalysisResults/ang/344810/AnalysisResultsFinal.root",
+                 "/rstorage/alice/AnalysisResults/ang/344912/AnalysisResultsFinal.root"]
+response_labels: ["PYTHIA8", "Herwig7"]
 rebin_theory_response: False
 
 

--- a/pyjetty/alice_analysis/config/ang/angularity_R0.4_ptbin3.yaml
+++ b/pyjetty/alice_analysis/config/ang/angularity_R0.4_ptbin3.yaml
@@ -164,7 +164,8 @@ theory_dir: "/home/ezra/theory_predictions/"
 pt_scale_factors_filename: "qg_fractions-ALICE-R04.txt"
 theory_pt_bins: [10, 15, 20, 25, 30, 35, 40, 45, 50, 60, 70, 80, 90, 100,
                  110, 120, 130, 140, 150, 160, 170, 180, 190, 200]
-response_files: ["/rstorage/alice/AnalysisResults/ang/344810/AnalysisResultsFinal.root",
+Omega_list: [0.1, 0.3, 0.8]
+response_files: ["/rstorage/alice/AnalysisResults/ang/353823/AnalysisResultsFinal.root",
                  "/rstorage/alice/AnalysisResults/ang/344912/AnalysisResultsFinal.root"]
 response_labels: ["PYTHIA8", "Herwig7"]
 rebin_theory_response: False

--- a/pyjetty/alice_analysis/config/ang/angularity_R0.4_ptbin3.yaml
+++ b/pyjetty/alice_analysis/config/ang/angularity_R0.4_ptbin3.yaml
@@ -18,7 +18,7 @@ jet_matching_distance: 0.6        # Match jets with deltaR < jet_matching_distan
 reject_tracks_fraction: 0
 
 # SoftDrop setting (current same for all SD plots)
-sd_zcut: 0.1    # multiplier
+sd_zcut: 0.2    # multiplier
 sd_beta: 0      # exponent on (deltaR / R)
 
 
@@ -160,7 +160,8 @@ ang:
 # Theory comparison parameters
 do_theory_comp: True
 theory_beta: [1.5, 2, 3]
-theory_dir: "/home/ezra/ALICE_table_old/"
+theory_dir: "/home/ezra/theory_predictions/"
+pt_scale_factors_filename: "qg_fractions-ALICE-R04.txt"
 theory_pt_bins: [10, 15, 20, 25, 30, 35, 40, 45, 50, 60, 70, 80, 90, 100,
                  110, 120, 130, 140, 150, 160, 170, 180, 190, 200]
 response_files: ["/rstorage/alice/AnalysisResults/ang/344810/AnalysisResultsFinal.root",
@@ -202,10 +203,10 @@ systematics_list:
 
 # Paths to processing output, to be used for unfolding
 main_data: '/rstorage/alice/AnalysisResults/ang/287220/AnalysisResultsFinal.root'
-main_response: '/rstorage/alice/AnalysisResults/ang/287381/AnalysisResultsFinal.root'
-trkeff_response: '/rstorage/alice/AnalysisResults/ang/287382/AnalysisResultsFinal.root'
+main_response: '/rstorage/alice/AnalysisResults/ang/351487/AnalysisResultsFinal.root'
+trkeff_response: '/rstorage/alice/AnalysisResults/ang/351489/AnalysisResultsFinal.root'
 randmass_data: '/rstorage/alice/AnalysisResults/ang/287383/AnalysisResultsFinal.root'
-randmass_response: '/rstorage/alice/AnalysisResults/ang/287384/AnalysisResultsFinal.root'
+randmass_response: '/rstorage/alice/AnalysisResults/ang/351488/AnalysisResultsFinal.root'
 fastsim_response: ['/rstorage/alice/AnalysisResults/ang/287385/AnalysisResultsFinal.root',
                    '/rstorage/alice/AnalysisResults/ang/287386/AnalysisResultsFinal.root']
 

--- a/pyjetty/alice_analysis/config/ang/angularity_R0.4_ptbin3.yaml
+++ b/pyjetty/alice_analysis/config/ang/angularity_R0.4_ptbin3.yaml
@@ -160,12 +160,11 @@ ang:
 # Theory comparison parameters
 do_theory_comp: True
 theory_beta: [1.5, 2, 3]
-theory_dir: "/home/ezra/ALICE_table/"
+theory_dir: "/home/ezra/ALICE_table_old/"
 theory_pt_bins: [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150]
 response_files: ["/rstorage/alice/AnalysisResults/ang/196181/AnalysisResultsFinal.root",
-                 "/rstorage/alice/AnalysisResults/ang/286620/AnalysisResultsFinal.root",
                  "/rstorage/alice/AnalysisResults/ang/225271/AnalysisResultsFinal.root"]
-response_labels: ["PYTHIA8", "P8time", "Herwig7"]
+response_labels: ["PYTHIA8", "Herwig7"]
 rebin_theory_response: False
 
 
@@ -173,7 +172,7 @@ rebin_theory_response: False
 # Analysis & plotting parameters
 file_format: ".pdf"
 output_dir: "/rstorage/alice/AnalysisResults/ang/AngR04_ptbin3"
-roounfold_path: "/home/ezra/heppy/external/roounfold/roounfold-2.0.0/lib/libRooUnfold.so"
+roounfold_path: "/home/ezra/heppy/external/roounfold/roounfold-current/lib/libRooUnfold.so"
 
 analysis_observable: 'ang'
 do_unfolding: False

--- a/pyjetty/alice_analysis/config/ang/angularity_R0.4_ptbin3.yaml
+++ b/pyjetty/alice_analysis/config/ang/angularity_R0.4_ptbin3.yaml
@@ -161,9 +161,10 @@ ang:
 do_theory_comp: True
 theory_beta: [1.5, 2, 3]
 theory_dir: "/home/ezra/ALICE_table_old/"
-theory_pt_bins: [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150]
-response_files: ["/rstorage/alice/AnalysisResults/ang/196181/AnalysisResultsFinal.root",
-                 "/rstorage/alice/AnalysisResults/ang/225271/AnalysisResultsFinal.root"]
+theory_pt_bins: [10, 15, 20, 25, 30, 35, 40, 45, 50, 60, 70, 80, 90, 100,
+                 110, 120, 130, 140, 150, 160, 170, 180, 190, 200]
+response_files: ["/rstorage/alice/AnalysisResults/ang/344810/AnalysisResultsFinal.root",
+                 "/rstorage/alice/AnalysisResults/ang/344912/AnalysisResultsFinal.root"]
 response_labels: ["PYTHIA8", "Herwig7"]
 rebin_theory_response: False
 

--- a/pyjetty/alice_analysis/config/ang/angularity_R0.4_ptbin4.yaml
+++ b/pyjetty/alice_analysis/config/ang/angularity_R0.4_ptbin4.yaml
@@ -158,7 +158,7 @@ ang:
 
 ###############################################################################
 # Theory comparison parameters
-do_theory_comp: True
+do_theory_comp: False
 theory_beta: [1.5, 2, 3]
 theory_dir: "/home/ezra/theory_predictions/"
 pt_scale_factors_filename: "qg_fractions-ALICE-R04.txt"
@@ -177,8 +177,8 @@ output_dir: "/rstorage/alice/AnalysisResults/ang/AngR04_ptbin4"
 roounfold_path: "/home/ezra/heppy/external/roounfold/roounfold-current/lib/libRooUnfold.so"
 
 analysis_observable: 'ang'
-do_unfolding: False
-force_rebin: False
+do_unfolding: True
+force_rebin: True
 do_systematics: True
 do_plot_final_result: True
 do_plot_performance: False

--- a/pyjetty/alice_analysis/config/ang/angularity_R0.4_ptbin4.yaml
+++ b/pyjetty/alice_analysis/config/ang/angularity_R0.4_ptbin4.yaml
@@ -18,7 +18,7 @@ jet_matching_distance: 0.6        # Match jets with deltaR < jet_matching_distan
 reject_tracks_fraction: 0
 
 # SoftDrop setting (current same for all SD plots)
-sd_zcut: 0.1    # multiplier
+sd_zcut: 0.2    # multiplier
 sd_beta: 0      # exponent on (deltaR / R)
 
 
@@ -160,7 +160,8 @@ ang:
 # Theory comparison parameters
 do_theory_comp: True
 theory_beta: [1.5, 2, 3]
-theory_dir: "/home/ezra/ALICE_table/"
+theory_dir: "/home/ezra/theory_predictions/"
+pt_scale_factors_filename: "qg_fractions-ALICE-R04.txt"
 theory_pt_bins: [10, 15, 20, 25, 30, 35, 40, 45, 50, 60, 70, 80, 90, 100,
                  110, 120, 130, 140, 150, 160, 170, 180, 190, 200]
 response_files: ["/rstorage/alice/AnalysisResults/ang/344810/AnalysisResultsFinal.root",
@@ -202,10 +203,10 @@ systematics_list:
 
 # Paths to processing output, to be used for unfolding
 main_data: '/rstorage/alice/AnalysisResults/ang/287220/AnalysisResultsFinal.root'
-main_response: '/rstorage/alice/AnalysisResults/ang/287381/AnalysisResultsFinal.root'
-trkeff_response: '/rstorage/alice/AnalysisResults/ang/287382/AnalysisResultsFinal.root'
+main_response: '/rstorage/alice/AnalysisResults/ang/351487/AnalysisResultsFinal.root'
+trkeff_response: '/rstorage/alice/AnalysisResults/ang/351489/AnalysisResultsFinal.root'
 randmass_data: '/rstorage/alice/AnalysisResults/ang/287383/AnalysisResultsFinal.root'
-randmass_response: '/rstorage/alice/AnalysisResults/ang/287384/AnalysisResultsFinal.root'
+randmass_response: '/rstorage/alice/AnalysisResults/ang/351488/AnalysisResultsFinal.root'
 fastsim_response: ['/rstorage/alice/AnalysisResults/ang/287385/AnalysisResultsFinal.root',
                    '/rstorage/alice/AnalysisResults/ang/287386/AnalysisResultsFinal.root']
 

--- a/pyjetty/alice_analysis/config/ang/angularity_R0.4_ptbin4.yaml
+++ b/pyjetty/alice_analysis/config/ang/angularity_R0.4_ptbin4.yaml
@@ -161,7 +161,7 @@ ang:
 do_theory_comp: True
 theory_beta: [1.5, 2, 3]
 theory_dir: "/home/ezra/ALICE_table/"
-theory_pt_bins: [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150]
+theory_pt_bins: [10, 15, 20, 25, 30, 35, 40, 45, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150]
 response_files: ["/rstorage/alice/AnalysisResults/ang/196181/AnalysisResultsFinal.root",
                  "/rstorage/alice/AnalysisResults/ang/286620/AnalysisResultsFinal.root",
                  "/rstorage/alice/AnalysisResults/ang/225271/AnalysisResultsFinal.root"]
@@ -173,7 +173,7 @@ rebin_theory_response: False
 # Analysis & plotting parameters
 file_format: ".pdf"
 output_dir: "/rstorage/alice/AnalysisResults/ang/AngR04_ptbin4"
-roounfold_path: "/home/ezra/heppy/external/roounfold/roounfold-2.0.0/lib/libRooUnfold.so"
+roounfold_path: "/home/ezra/heppy/external/roounfold/roounfold-current/lib/libRooUnfold.so"
 
 analysis_observable: 'ang'
 do_unfolding: False

--- a/pyjetty/alice_analysis/config/ang/angularity_R0.4_ptbin4.yaml
+++ b/pyjetty/alice_analysis/config/ang/angularity_R0.4_ptbin4.yaml
@@ -158,13 +158,14 @@ ang:
 
 ###############################################################################
 # Theory comparison parameters
-do_theory_comp: False
+do_theory_comp: True
 theory_beta: [1.5, 2, 3]
 theory_dir: "/home/ezra/theory_predictions/"
 pt_scale_factors_filename: "qg_fractions-ALICE-R04.txt"
 theory_pt_bins: [10, 15, 20, 25, 30, 35, 40, 45, 50, 60, 70, 80, 90, 100,
                  110, 120, 130, 140, 150, 160, 170, 180, 190, 200]
-response_files: ["/rstorage/alice/AnalysisResults/ang/344810/AnalysisResultsFinal.root",
+Omega_list: [0.1, 0.3, 0.8]
+response_files: ["/rstorage/alice/AnalysisResults/ang/353823/AnalysisResultsFinal.root",
                  "/rstorage/alice/AnalysisResults/ang/344912/AnalysisResultsFinal.root"]
 response_labels: ["PYTHIA8", "Herwig7"]
 rebin_theory_response: False
@@ -177,8 +178,8 @@ output_dir: "/rstorage/alice/AnalysisResults/ang/AngR04_ptbin4"
 roounfold_path: "/home/ezra/heppy/external/roounfold/roounfold-current/lib/libRooUnfold.so"
 
 analysis_observable: 'ang'
-do_unfolding: True
-force_rebin: True
+do_unfolding: False
+force_rebin: False
 do_systematics: True
 do_plot_final_result: True
 do_plot_performance: False

--- a/pyjetty/alice_analysis/config/ang/angularity_R0.4_ptbin4.yaml
+++ b/pyjetty/alice_analysis/config/ang/angularity_R0.4_ptbin4.yaml
@@ -161,11 +161,11 @@ ang:
 do_theory_comp: True
 theory_beta: [1.5, 2, 3]
 theory_dir: "/home/ezra/ALICE_table/"
-theory_pt_bins: [10, 15, 20, 25, 30, 35, 40, 45, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150]
-response_files: ["/rstorage/alice/AnalysisResults/ang/196181/AnalysisResultsFinal.root",
-                 "/rstorage/alice/AnalysisResults/ang/286620/AnalysisResultsFinal.root",
-                 "/rstorage/alice/AnalysisResults/ang/225271/AnalysisResultsFinal.root"]
-response_labels: ["PYTHIA8", "P8time", "Herwig7"]
+theory_pt_bins: [10, 15, 20, 25, 30, 35, 40, 45, 50, 60, 70, 80, 90, 100,
+                 110, 120, 130, 140, 150, 160, 170, 180, 190, 200]
+response_files: ["/rstorage/alice/AnalysisResults/ang/344810/AnalysisResultsFinal.root",
+                 "/rstorage/alice/AnalysisResults/ang/344912/AnalysisResultsFinal.root"]
+response_labels: ["PYTHIA8", "Herwig7"]
 rebin_theory_response: False
 
 

--- a/pyjetty/alice_analysis/process/user/ang_pp/pythia_parton_hadron.py
+++ b/pyjetty/alice_analysis/process/user/ang_pp/pythia_parton_hadron.py
@@ -13,8 +13,6 @@ import yaml
 import copy
 import argparse
 import os
-import array
-import numpy as np
 
 from pyjetty.mputils import *
 
@@ -25,6 +23,9 @@ import pythiaext
 
 from pyjetty.alice_analysis.process.base import process_base
 from pyjetty.alice_analysis.process.user.ang_pp.helpers import lambda_beta_kappa_i
+
+from array import array
+import numpy as np
 
 # Prevent ROOT from stealing focus when plotting
 ROOT.gROOT.SetBatch(True)
@@ -498,20 +499,27 @@ class pythia_parton_hadron(process_base.ProcessBase):
                     dim = 4
                     title = ['p_{T}^{ch jet}', 'p_{T}^{parton jet}', 
                              '#lambda_{#beta}^{ch}', '#lambda_{#beta}^{parton}']
-                    nbins = [14, 14, 100, 101]
-                    min_li = [ 10.,  10., 0.,  -0.005]
-                    max_li = [150., 150., 1.0,  1.005]
+                    pt_bins = array('d', list(range(10, 50, 5)) + list(range(50, 160, 10)))
+                    obs_bins = np.concatenate((np.linspace(0, 0.009, 10), np.linspace(0.01, 0.1, 19),
+                                               np.linspace(0.11, 1., 90)))
+                    nbins  = [len(pt_bins)-1, len(pt_bins)-1, len(obs_bins)-1, len(obs_bins)-1]
+                    min_li = [pt_bins[0],     pt_bins[0],     obs_bins[0],     obs_bins[0]    ]
+                    max_li = [pt_bins[-1],    pt_bins[-1],    obs_bins[-1],    obs_bins[-1]   ]
 
                     name = 'hResponse_JetPt_ang_ch_%s' % label
                     nbins = (nbins)
                     xmin = (min_li)
                     xmax = (max_li)
-                    nbins_array = array.array('i', nbins)
-                    xmin_array = array.array('d', xmin)
-                    xmax_array = array.array('d', xmax)
+                    nbins_array = array('i', nbins)
+                    xmin_array = array('d', xmin)
+                    xmax_array = array('d', xmax)
                     h = ROOT.THnF(name, name, dim, nbins_array, xmin_array, xmax_array)
                     for i in range(0, dim):
                         h.GetAxis(i).SetTitle(title[i])
+                        if i == 0 or i == 1:
+                            h.SetBinEdges(i, pt_bins)
+                        else:  # i == 2 or i == 3
+                            h.SetBinEdges(i, obs_bins)
                     h.Sumw2()
                     setattr(self, name, h)
                     getattr(self, hist_list_name).append(h)
@@ -525,6 +533,10 @@ class pythia_parton_hadron(process_base.ProcessBase):
                             h = ROOT.THnF(name, name, dim, nbins_array, xmin_array, xmax_array)
                             for i in range(0, dim):
                                 h.GetAxis(i).SetTitle(title[i])
+                                if i == 0 or i == 1:
+                                    h.SetBinEdges(i, pt_bins)
+                                else:  # i == 2 or i == 3
+                                    h.SetBinEdges(i, obs_bins)
                             h.Sumw2()
                             setattr(self, name, h)
                             getattr(self, hist_list_name).append(h)
@@ -537,6 +549,10 @@ class pythia_parton_hadron(process_base.ProcessBase):
                     h = ROOT.THnF(name, name, dim, nbins_array, xmin_array, xmax_array)
                     for i in range(0, dim):
                         h.GetAxis(i).SetTitle(title[i])
+                        if i == 0 or i == 1:
+                            h.SetBinEdges(i, pt_bins)
+                        else:  # i == 2 or i == 3
+                            h.SetBinEdges(i, obs_bins)
                     h.Sumw2()
                     setattr(self, name, h)
                     getattr(self, hist_list_name).append(h)
@@ -550,6 +566,10 @@ class pythia_parton_hadron(process_base.ProcessBase):
                             h = ROOT.THnF(name, name, dim, nbins_array, xmin_array, xmax_array)
                             for i in range(0, dim):
                                 h.GetAxis(i).SetTitle(title[i])
+                                if i == 0 or i == 1:
+                                    h.SetBinEdges(i, pt_bins)
+                                else:  # i == 2 or i == 3
+                                    h.SetBinEdges(i, obs_bins)
                             h.Sumw2()
                             setattr(self, name, h)
                             getattr(self, hist_list_name).append(h)
@@ -950,11 +970,11 @@ class pythia_parton_hadron(process_base.ProcessBase):
 
             # 4D response matrices for "forward folding" to ch level
             x = ([jch.pt(), jp.pt(), lch, lp])
-            x_array = array.array('d', x)
+            x_array = array('d', x)
             getattr(self, 'hResponse_JetPt_ang_ch_%s' % label).Fill(x_array)
 
             x = ([jh.pt(), jp.pt(), lh, lp])
-            x_array = array.array('d', x)
+            x_array = array('d', x)
             getattr(self, 'hResponse_JetPt_ang_h_%s' % label).Fill(x_array)
 
             if self.use_SD:
@@ -973,11 +993,11 @@ class pythia_parton_hadron(process_base.ProcessBase):
                     lp_sd = fjext.lambda_beta_kappa(jp, jet_sd_p, beta, kappa, jetR)
 
                     x = ([jch.pt(), jp.pt(), lch_sd, lp_sd])
-                    x_array = array.array('d', x)
+                    x_array = array('d', x)
                     getattr(self, 'hResponse_JetPt_ang_ch_%s_%s' % (label, gl)).Fill(x_array)
 
                     x = ([jh.pt(), jp.pt(), lh, lp])
-                    x_array = array.array('d', x)
+                    x_array = array('d', x)
                     getattr(self, 'hResponse_JetPt_ang_h_%s_%s' % (label, gl)).Fill(x_array)
 
 

--- a/pyjetty/alice_analysis/process/user/ang_pp/pythia_parton_hadron.py
+++ b/pyjetty/alice_analysis/process/user/ang_pp/pythia_parton_hadron.py
@@ -83,8 +83,9 @@ class pythia_parton_hadron(process_base.ProcessBase):
         self.calculate_events(pythia_MPI, MPIon=True)
         print()
 
-        for jetR in self.jetR_list:
-            getattr(self, "tw_R%s" % str(jetR).replace('.', '')).fill_tree()
+        if not self.no_tree:
+            for jetR in self.jetR_list:
+                getattr(self, "tw_R%s" % str(jetR).replace('.', '')).fill_tree()
 
         self.scale_print_final_info(pythia, pythia_MPI)
 
@@ -115,7 +116,7 @@ class pythia_parton_hadron(process_base.ProcessBase):
         self.beta_list = config["betas"]
 
         # SoftDrop parameters
-        self.use_SD = False   # Change this to use SD
+        self.use_SD = True   # Change this to use SD
         self.sd_beta = config["sd_beta"]
         self.sd_zcut = config["sd_zcut"]
         self.grooming_settings = [{'sd': [self.sd_zcut, self.sd_beta]}]  # self.utils.grooming_settings
@@ -126,16 +127,22 @@ class pythia_parton_hadron(process_base.ProcessBase):
 
         self.n_pt_bins = config["n_pt_bins"]
         self.pt_limits = config["pt_limits"]
-        self.pTbins = np.arange(self.pt_limits[0], self.pt_limits[1] + 1, 
-                                (self.pt_limits[1] - self.pt_limits[0]) / self.n_pt_bins)
         self.n_lambda_bins = config['n_lambda_bins']
         self.lambda_limits = config['lambda_limits']
+
+        # Manually added binnings for RM and scaling histograms
+        self.pt_bins = array('d', list(range(10, 50, 5)) + list(range(50, 210, 10)))
+        self.obs_bins = np.concatenate((np.linspace(0, 0.009, 10), np.linspace(0.01, 0.1, 19),
+                                   np.linspace(0.11, 1., 90)))
 
         # hadron level - ALICE tracking restriction
         self.max_eta_hadron = 0.9
 
         # Whether or not to rescale final jet histograms based on sigma/N
         self.no_scale = args.no_scale
+
+        # Whether or not to save particle info in raw tree structure
+        self.no_tree = args.no_tree
  
 
     #---------------------------------------------------------------
@@ -151,6 +158,8 @@ class pythia_parton_hadron(process_base.ProcessBase):
             # Store a list of all the histograms just so that we can rescale them later
             hist_list_name = "hist_list_R%s" % str(jetR).replace('.', '')
             setattr(self, hist_list_name, [])
+            hist_list_name_MPIon = "hist_list_MPIon_R%s" % str(jetR).replace('.', '')
+            setattr(self, hist_list_name_MPIon, [])
 
             R_label = str(jetR).replace('.', '') + 'Scaled'
 
@@ -218,6 +227,7 @@ class pythia_parton_hadron(process_base.ProcessBase):
                 setattr(self, name, h)
                 getattr(self, hist_list_name).append(h)
 
+                '''
                 # Jet multiplicity for matched jets with a cut at ch-jet level
                 name = 'hNconstit_Pt_ch_PtBinCH60-80_R%s' % R_label
                 h = ROOT.TH2F(name, name, 300, 0, 300, 50, 0.5, 50.5)
@@ -242,51 +252,97 @@ class pythia_parton_hadron(process_base.ProcessBase):
                 h.Sumw2()
                 setattr(self, name, h)
                 getattr(self, hist_list_name).append(h)
+                '''
 
             for beta in self.beta_list:
 
-                label = ("R%s_%sScaled" % (str(jetR), str(beta))).replace('.', '')
+                label = ("R%s_%s" % (str(jetR), str(beta))).replace('.', '')
 
                 if self.level in [None, 'ch']:
-                    name = 'hAng_JetPt_ch_%s' % label
-                    h = ROOT.TH2F(name, name, self.n_pt_bins, self.pt_limits[0], self.pt_limits[1],
-                                  self.n_lambda_bins, self.lambda_limits[0], self.lambda_limits[1])
+                    name = 'hAng_JetPt_ch_%sScaled' % label
+                    h = ROOT.TH2F(name, name, len(self.pt_bins)-1, self.pt_bins,
+                                  len(self.obs_bins)-1, self.obs_bins)
                     h.GetXaxis().SetTitle('p_{T}^{ch jet}')
                     h.GetYaxis().SetTitle('#frac{dN}{d#lambda_{#beta=%s}^{ch}}' % str(beta))
                     h.Sumw2()
                     setattr(self, name, h)
                     getattr(self, hist_list_name).append(h)
 
-                    name = 'hAng_JetPt_ch_MPIon_%s' % label
-                    h = ROOT.TH2F(name, name, self.n_pt_bins, self.pt_limits[0], self.pt_limits[1],
-                                  self.n_lambda_bins, self.lambda_limits[0], self.lambda_limits[1])
+                    name = 'hAng_JetPt_ch_MPIon_%sScaled' % label
+                    h = ROOT.TH2F(name, name, len(self.pt_bins)-1, self.pt_bins,
+                                  len(self.obs_bins)-1, self.obs_bins)
                     h.GetXaxis().SetTitle('p_{T}^{ch jet}')
                     h.GetYaxis().SetTitle('#frac{dN}{d#lambda_{#beta=%s}^{ch}}' % str(beta))
                     h.Sumw2()
                     setattr(self, name, h)
+                    getattr(self, hist_list_name_MPIon).append(h)
+
+                    if self.use_SD:
+                        # SoftDrop groomed jet histograms for MPI scaling
+                        for gl in self.grooming_labels:
+                            name = 'hAng_JetPt_ch_%s_%sScaled' % (label, gl)
+                            h = ROOT.TH2F(name, name, len(self.pt_bins)-1, self.pt_bins,
+                                          len(self.obs_bins)-1, self.obs_bins)
+                            h.GetXaxis().SetTitle('p_{T}^{ch jet}')
+                            h.GetYaxis().SetTitle('#frac{dN}{d#lambda_{#beta=%s}^{ch}}' % str(beta))
+                            h.Sumw2()
+                            setattr(self, name, h)
+                            getattr(self, hist_list_name).append(h)
+
+                            name = 'hAng_JetPt_ch_MPIon_%s_%sScaled' % (label, gl)
+                            h = ROOT.TH2F(name, name, len(self.pt_bins)-1, self.pt_bins,
+                                          len(self.obs_bins)-1, self.obs_bins)
+                            h.GetXaxis().SetTitle('p_{T}^{ch jet}')
+                            h.GetYaxis().SetTitle('#frac{dN}{d#lambda_{#beta=%s}^{ch}}' % str(beta))
+                            h.Sumw2()
+                            setattr(self, name, h)
+                            getattr(self, hist_list_name_MPIon).append(h)
 
                 if self.level in [None, 'h']:
-                    name = 'hAng_JetPt_h_%s' % label
-                    h = ROOT.TH2F(name, name, self.n_pt_bins, self.pt_limits[0], self.pt_limits[1],
-                                  self.n_lambda_bins, self.lambda_limits[0], self.lambda_limits[1])
+                    name = 'hAng_JetPt_h_%sScaled' % label
+                    h = ROOT.TH2F(name, name, len(self.pt_bins)-1, self.pt_bins,
+                                  len(self.obs_bins)-1, self.obs_bins)
                     h.GetXaxis().SetTitle('p_{T}^{jet, h}')
                     h.GetYaxis().SetTitle('#frac{dN}{d#lambda_{#beta=%s}^{h}}' % str(beta))
                     h.Sumw2()
                     setattr(self, name, h)
                     getattr(self, hist_list_name).append(h)
 
+                    if self.use_SD:
+                        for gl in self.grooming_labels:
+                            name = 'hAng_JetPt_h_%s_%sScaled' % (label, gl)
+                            h = ROOT.TH2F(name, name, len(self.pt_bins)-1, self.pt_bins,
+                                          len(self.obs_bins)-1, self.obs_bins)
+                            h.GetXaxis().SetTitle('p_{T}^{jet, h}')
+                            h.GetYaxis().SetTitle('#frac{dN}{d#lambda_{#beta=%s}^{h}}' % str(beta))
+                            h.Sumw2()
+                            setattr(self, name, h)
+                            getattr(self, hist_list_name).append(h)
+                            
+
                 if self.level in [None, 'p']:
-                    name = 'hAng_JetPt_p_%s' % label
-                    h = ROOT.TH2F(name, name, self.n_pt_bins, self.pt_limits[0], self.pt_limits[1],
-                                  self.n_lambda_bins, self.lambda_limits[0], self.lambda_limits[1])
+                    name = 'hAng_JetPt_p_%sScaled' % label
+                    h = ROOT.TH2F(name, name, len(self.pt_bins)-1, self.pt_bins,
+                                  len(self.obs_bins)-1, self.obs_bins)
                     h.GetXaxis().SetTitle('p_{T}^{jet, parton}')
                     h.GetYaxis().SetTitle('#frac{dN}{d#lambda_{#beta=%s}^{parton}}' % str(beta))
                     h.Sumw2()
                     setattr(self, name, h)
                     getattr(self, hist_list_name).append(h)
 
+                    if self.use_SD:
+                        for gl in self.grooming_labels:
+                            name = 'hAng_JetPt_p_%s_%sScaled' % (label, gl)
+                            h = ROOT.TH2F(name, name, len(self.pt_bins)-1, self.pt_bins,
+                                          len(self.obs_bins)-1, self.obs_bins)
+                            h.GetXaxis().SetTitle('p_{T}^{jet, parton}')
+                            h.GetYaxis().SetTitle('#frac{dN}{d#lambda_{#beta=%s}^{parton}}' % str(beta))
+                            h.Sumw2()
+                            setattr(self, name, h)
+                            getattr(self, hist_list_name).append(h)
+
                 if self.level == None:
-                    name = 'hResponse_ang_%s' % label
+                    name = 'hResponse_ang_%sScaled' % label
                     h = ROOT.TH2F(name, name, 100, 0, 1, 100, 0, 1)
                     h.GetXaxis().SetTitle('#lambda_{#beta=%s}^{parton}' % beta)
                     h.GetYaxis().SetTitle('#lambda_{#beta=%s}^{ch}' % beta)
@@ -294,7 +350,18 @@ class pythia_parton_hadron(process_base.ProcessBase):
                     setattr(self, name, h)
                     getattr(self, hist_list_name).append(h)
 
-                    name = 'hResponse_ang_PtBinCH20-40_%s' % label
+                    if self.use_SD:
+                        for gl in self.grooming_labels:
+                            name = 'hResponse_ang_%s_%sScaled' % (label, gl)
+                            h = ROOT.TH2F(name, name, 100, 0, 1, 100, 0, 1)
+                            h.GetXaxis().SetTitle('#lambda_{#beta=%s}^{parton}' % beta)
+                            h.GetYaxis().SetTitle('#lambda_{#beta=%s}^{ch}' % beta)
+                            h.Sumw2()
+                            setattr(self, name, h)
+                            getattr(self, hist_list_name).append(h)
+
+                    '''
+                    name = 'hResponse_ang_PtBinCH20-40_%sScaled' % label
                     h = ROOT.TH2F(name, name, 100, 0, 1, 100, 0, 1)
                     h.GetXaxis().SetTitle('#lambda_{#beta=%s}^{parton}' % beta)
                     h.GetYaxis().SetTitle('#lambda_{#beta=%s}^{ch}' % beta)
@@ -302,7 +369,7 @@ class pythia_parton_hadron(process_base.ProcessBase):
                     setattr(self, name, h)
                     getattr(self, hist_list_name).append(h)
 
-                    name = 'hResponse_ang_PtBinCH40-60_%s' % label
+                    name = 'hResponse_ang_PtBinCH40-60_%sScaled' % label
                     h = ROOT.TH2F(name, name, 100, 0, 1, 100, 0, 1)
                     h.GetXaxis().SetTitle('#lambda_{#beta=%s}^{parton}' % beta)
                     h.GetYaxis().SetTitle('#lambda_{#beta=%s}^{ch}' % beta)
@@ -310,7 +377,7 @@ class pythia_parton_hadron(process_base.ProcessBase):
                     setattr(self, name, h)
                     getattr(self, hist_list_name).append(h)
 
-                    name = 'hResponse_ang_PtBinCH60-80_%s' % label
+                    name = 'hResponse_ang_PtBinCH60-80_%sScaled' % label
                     h = ROOT.TH2F(name, name, 100, 0, 1, 100, 0, 1)
                     h.GetXaxis().SetTitle('#lambda_{#beta=%s}^{parton}' % beta)
                     h.GetYaxis().SetTitle('#lambda_{#beta=%s}^{ch}' % beta)
@@ -319,7 +386,7 @@ class pythia_parton_hadron(process_base.ProcessBase):
                     getattr(self, hist_list_name).append(h)
 
                     # Phase space plots integrated over all pT bins
-                    name = 'hPhaseSpace_DeltaR_Pt_ch_%s' % label
+                    name = 'hPhaseSpace_DeltaR_Pt_ch_%sScaled' % label
                     h = ROOT.TH2F(name, name, self.n_pt_bins, self.pt_limits[0], self.pt_limits[1],
                                   150, 0, 1.5)
                     h.GetXaxis().SetTitle('(p_{T, i})_{ch jet}')
@@ -328,7 +395,7 @@ class pythia_parton_hadron(process_base.ProcessBase):
                     setattr(self, name, h)
                     getattr(self, hist_list_name).append(h)
 
-                    name = 'hPhaseSpace_ang_DeltaR_ch_%s' % label
+                    name = 'hPhaseSpace_ang_DeltaR_ch_%sScaled' % label
                     h = ROOT.TH2F(name, name, 150, 0, 1.5,
                                   self.n_lambda_bins, self.lambda_limits[0], self.lambda_limits[1])
                     h.GetXaxis().SetTitle('(#Delta R_{i})_{ch jet} / R')
@@ -337,7 +404,7 @@ class pythia_parton_hadron(process_base.ProcessBase):
                     setattr(self, name, h)
                     getattr(self, hist_list_name).append(h)
 
-                    name = 'hPhaseSpace_ang_Pt_ch_%s' % label
+                    name = 'hPhaseSpace_ang_Pt_ch_%sScaled' % label
                     h = ROOT.TH2F(name, name, self.n_pt_bins, self.pt_limits[0], self.pt_limits[1],
                                   self.n_lambda_bins, self.lambda_limits[0], self.lambda_limits[1])
                     h.GetXaxis().SetTitle('(p_{T, i})_{ch jet}')
@@ -346,7 +413,7 @@ class pythia_parton_hadron(process_base.ProcessBase):
                     setattr(self, name, h)
                     getattr(self, hist_list_name).append(h)
 
-                    name = 'hPhaseSpace_DeltaR_Pt_p_%s' % label
+                    name = 'hPhaseSpace_DeltaR_Pt_p_%sScaled' % label
                     h = ROOT.TH2F(name, name, self.n_pt_bins, self.pt_limits[0], self.pt_limits[1],
                                   150, 0, 1.5)
                     h.GetXaxis().SetTitle('(p_{T, i})_{parton jet}')
@@ -355,7 +422,7 @@ class pythia_parton_hadron(process_base.ProcessBase):
                     setattr(self, name, h)
                     getattr(self, hist_list_name).append(h)
 
-                    name = 'hPhaseSpace_ang_DeltaR_p_%s' % label
+                    name = 'hPhaseSpace_ang_DeltaR_p_%sScaled' % label
                     h = ROOT.TH2F(name, name, 150, 0, 1.5,
                                   self.n_lambda_bins, self.lambda_limits[0], self.lambda_limits[1])
                     h.GetXaxis().SetTitle('(#Delta R_{i})_{parton jet} / R')
@@ -364,7 +431,7 @@ class pythia_parton_hadron(process_base.ProcessBase):
                     setattr(self, name, h)
                     getattr(self, hist_list_name).append(h)
 
-                    name = 'hPhaseSpace_ang_Pt_p_%s' % label
+                    name = 'hPhaseSpace_ang_Pt_p_%sScaled' % label
                     h = ROOT.TH2F(name, name, self.n_pt_bins, self.pt_limits[0], self.pt_limits[1],
                                   self.n_lambda_bins, self.lambda_limits[0], self.lambda_limits[1])
                     h.GetXaxis().SetTitle('(p_{T, i})_{parton jet}')
@@ -374,7 +441,7 @@ class pythia_parton_hadron(process_base.ProcessBase):
                     getattr(self, hist_list_name).append(h)
 
                     # Phase space plots binned in ch jet pT
-                    name = 'hPhaseSpace_DeltaR_Pt_ch_PtBinCH60-80_%s' % label
+                    name = 'hPhaseSpace_DeltaR_Pt_ch_PtBinCH60-80_%sScaled' % label
                     h = ROOT.TH2F(name, name, self.n_pt_bins, self.pt_limits[0], self.pt_limits[1],
                                   150, 0, 1.5)
                     h.GetXaxis().SetTitle('(p_{T, i})_{ch jet}')
@@ -383,7 +450,7 @@ class pythia_parton_hadron(process_base.ProcessBase):
                     setattr(self, name, h)
                     getattr(self, hist_list_name).append(h)
 
-                    name = 'hPhaseSpace_DeltaR_Pt_p_PtBinCH60-80_%s' % label
+                    name = 'hPhaseSpace_DeltaR_Pt_p_PtBinCH60-80_%sScaled' % label
                     h = ROOT.TH2F(name, name, self.n_pt_bins, self.pt_limits[0], self.pt_limits[1],
                                   150, 0, 1.5)
                     h.GetXaxis().SetTitle('(p_{T, i})_{parton jet}')
@@ -392,7 +459,7 @@ class pythia_parton_hadron(process_base.ProcessBase):
                     setattr(self, name, h)
                     getattr(self, hist_list_name).append(h)
 
-                    name = 'hPhaseSpace_ang_DeltaR_ch_PtBinCH60-80_%s' % label
+                    name = 'hPhaseSpace_ang_DeltaR_ch_PtBinCH60-80_%sScaled' % label
                     h = ROOT.TH2F(name, name, 150, 0, 1.5,
                                   self.n_lambda_bins, self.lambda_limits[0], self.lambda_limits[1])
                     h.GetXaxis().SetTitle('(#Delta R_{i})_{ch jet} / R')
@@ -400,7 +467,7 @@ class pythia_parton_hadron(process_base.ProcessBase):
                     setattr(self, name, h)
                     getattr(self, hist_list_name).append(h)
 
-                    name = 'hPhaseSpace_ang_DeltaR_p_PtBinCH60-80_%s' % label
+                    name = 'hPhaseSpace_ang_DeltaR_p_PtBinCH60-80_%sScaled' % label
                     h = ROOT.TH2F(name, name, 150, 0, 1.5,
                                   self.n_lambda_bins, self.lambda_limits[0], self.lambda_limits[1])
                     h.GetXaxis().SetTitle('(#Delta R_{i})_{parton jet} / R')
@@ -409,7 +476,7 @@ class pythia_parton_hadron(process_base.ProcessBase):
                     setattr(self, name, h)
                     getattr(self, hist_list_name).append(h)
 
-                    name = 'hPhaseSpace_ang_Pt_ch_PtBinCH60-80_%s' % label
+                    name = 'hPhaseSpace_ang_Pt_ch_PtBinCH60-80_%sScaled' % label
                     h = ROOT.TH2F(name, name, self.n_pt_bins, self.pt_limits[0], self.pt_limits[1],
                                   self.n_lambda_bins, self.lambda_limits[0], self.lambda_limits[1])
                     h.GetXaxis().SetTitle('(p_{T, i})_{ch jet}')
@@ -418,7 +485,7 @@ class pythia_parton_hadron(process_base.ProcessBase):
                     setattr(self, name, h)
                     getattr(self, hist_list_name).append(h)
 
-                    name = 'hPhaseSpace_ang_Pt_p_PtBinCH60-80_%s' % label
+                    name = 'hPhaseSpace_ang_Pt_p_PtBinCH60-80_%sScaled' % label
                     h = ROOT.TH2F(name, name, self.n_pt_bins, self.pt_limits[0], self.pt_limits[1],
                                   self.n_lambda_bins, self.lambda_limits[0], self.lambda_limits[1])
                     h.GetXaxis().SetTitle('(p_{T, i})_{parton jet}')
@@ -433,7 +500,7 @@ class pythia_parton_hadron(process_base.ProcessBase):
                     low_bound = self.annulus_plots_max_x / self.annulus_plots_num_r / 2.
                     up_bound = self.annulus_plots_max_x + low_bound
 
-                    name = 'hAnnulus_ang_ch_%s' % label
+                    name = 'hAnnulus_ang_ch_%sScaled' % label
                     h = ROOT.TH2F(name, name, self.annulus_plots_num_r, low_bound, up_bound,
                                   100, 0, 1.)
                     h.GetXaxis().SetTitle('(#it{r} / #it{R})_{ch jet}')
@@ -444,7 +511,7 @@ class pythia_parton_hadron(process_base.ProcessBase):
                     setattr(self, name, h)
                     getattr(self, hist_list_name).append(h)
 
-                    name = 'hAnnulus_ang_ch_PtBinCH60-80_%s' % label
+                    name = 'hAnnulus_ang_ch_PtBinCH60-80_%sScaled' % label
                     h = ROOT.TH2F(name, name, self.annulus_plots_num_r, low_bound, up_bound,
                                   100, 0, 1.)
                     h.GetXaxis().SetTitle('(#it{r} / #it{R})_{ch jet}')
@@ -455,7 +522,7 @@ class pythia_parton_hadron(process_base.ProcessBase):
                     setattr(self, name, h)
                     getattr(self, hist_list_name).append(h)
 
-                    name = 'hAnnulus_ang_p_%s' % label
+                    name = 'hAnnulus_ang_p_%sScaled' % label
                     h = ROOT.TH2F(name, name, self.annulus_plots_num_r, low_bound, up_bound,
                                   100, 0, 1.)
                     h.GetXaxis().SetTitle('(#it{r} / #it{R})_{parton jet}')
@@ -466,7 +533,7 @@ class pythia_parton_hadron(process_base.ProcessBase):
                     setattr(self, name, h)
                     getattr(self, hist_list_name).append(h)
 
-                    name = 'hAnnulus_ang_p_PtBinCH60-80_%s' % label
+                    name = 'hAnnulus_ang_p_PtBinCH60-80_%sScaled' % label
                     h = ROOT.TH2F(name, name, self.annulus_plots_num_r, low_bound, up_bound,
                                   100, 0, 1.)
                     h.GetXaxis().SetTitle('(#it{r} / #it{R})_{parton jet}')
@@ -476,8 +543,9 @@ class pythia_parton_hadron(process_base.ProcessBase):
                     h.Sumw2()
                     setattr(self, name, h)
                     getattr(self, hist_list_name).append(h)
+                    '''
 
-                    name = "hAngResidual_JetPt_%s" % label
+                    name = "hAngResidual_JetPt_%sScaled" % label
                     h = ROOT.TH2F(name, name, 300, 0, 300, 200, -3., 1.)
                     h.GetXaxis().SetTitle('p_{T}^{jet, parton}')
                     h.GetYaxis().SetTitle('#frac{#lambda_{#beta}^{jet, parton}-#lambda_{#beta}' + \
@@ -486,7 +554,7 @@ class pythia_parton_hadron(process_base.ProcessBase):
                     setattr(self, name, h)
                     getattr(self, hist_list_name).append(h)
 
-                    name = "hAngDiff_JetPt_%s" % label
+                    name = "hAngDiff_JetPt_%sScaled" % label
                     h = ROOT.TH2F(name, name, 300, 0, 300, 200, -2., 2.)
                     h.GetXaxis().SetTitle('#it{p}_{T}^{jet, ch}')
                     h.GetYaxis().SetTitle('#it{#lambda}_{#it{#beta}}^{jet, parton}-' + \
@@ -499,14 +567,14 @@ class pythia_parton_hadron(process_base.ProcessBase):
                     dim = 4
                     title = ['p_{T}^{ch jet}', 'p_{T}^{parton jet}', 
                              '#lambda_{#beta}^{ch}', '#lambda_{#beta}^{parton}']
-                    pt_bins = array('d', list(range(10, 50, 5)) + list(range(50, 160, 10)))
-                    obs_bins = np.concatenate((np.linspace(0, 0.009, 10), np.linspace(0.01, 0.1, 19),
-                                               np.linspace(0.11, 1., 90)))
-                    nbins  = [len(pt_bins)-1, len(pt_bins)-1, len(obs_bins)-1, len(obs_bins)-1]
-                    min_li = [pt_bins[0],     pt_bins[0],     obs_bins[0],     obs_bins[0]    ]
-                    max_li = [pt_bins[-1],    pt_bins[-1],    obs_bins[-1],    obs_bins[-1]   ]
+                    nbins  = [len(self.pt_bins)-1,  len(self.pt_bins)-1,
+                              len(self.obs_bins)-1, len(self.obs_bins)-1]
+                    min_li = [self.pt_bins[0],      self.pt_bins[0],
+                              self.obs_bins[0],     self.obs_bins[0]    ]
+                    max_li = [self.pt_bins[-1],     self.pt_bins[-1],
+                              self.obs_bins[-1],    self.obs_bins[-1]   ]
 
-                    name = 'hResponse_JetPt_ang_ch_%s' % label
+                    name = 'hResponse_JetPt_ang_ch_%sScaled' % label
                     nbins = (nbins)
                     xmin = (min_li)
                     xmax = (max_li)
@@ -517,26 +585,24 @@ class pythia_parton_hadron(process_base.ProcessBase):
                     for i in range(0, dim):
                         h.GetAxis(i).SetTitle(title[i])
                         if i == 0 or i == 1:
-                            h.SetBinEdges(i, pt_bins)
+                            h.SetBinEdges(i, self.pt_bins)
                         else:  # i == 2 or i == 3
-                            h.SetBinEdges(i, obs_bins)
+                            h.SetBinEdges(i, self.obs_bins)
                     h.Sumw2()
                     setattr(self, name, h)
                     getattr(self, hist_list_name).append(h)
 
                     if self.use_SD:
-
                         # SoftDrop groomed jet response matrices
                         for gl in self.grooming_labels:
-
-                            name = 'hResponse_JetPt_ang_ch_%s_%s' % (label, gl)
+                            name = 'hResponse_JetPt_ang_ch_%s_%sScaled' % (label, gl)
                             h = ROOT.THnF(name, name, dim, nbins_array, xmin_array, xmax_array)
                             for i in range(0, dim):
                                 h.GetAxis(i).SetTitle(title[i])
                                 if i == 0 or i == 1:
-                                    h.SetBinEdges(i, pt_bins)
+                                    h.SetBinEdges(i, self.pt_bins)
                                 else:  # i == 2 or i == 3
-                                    h.SetBinEdges(i, obs_bins)
+                                    h.SetBinEdges(i, self.obs_bins)
                             h.Sumw2()
                             setattr(self, name, h)
                             getattr(self, hist_list_name).append(h)
@@ -545,31 +611,29 @@ class pythia_parton_hadron(process_base.ProcessBase):
                     title = ['p_{T}^{h jet}', 'p_{T}^{parton jet}', 
                              '#lambda_{#beta}^{h}', '#lambda_{#beta}^{parton}']
 
-                    name = 'hResponse_JetPt_ang_h_%s' % label
+                    name = 'hResponse_JetPt_ang_h_%sScaled' % label
                     h = ROOT.THnF(name, name, dim, nbins_array, xmin_array, xmax_array)
                     for i in range(0, dim):
                         h.GetAxis(i).SetTitle(title[i])
                         if i == 0 or i == 1:
-                            h.SetBinEdges(i, pt_bins)
+                            h.SetBinEdges(i, self.pt_bins)
                         else:  # i == 2 or i == 3
-                            h.SetBinEdges(i, obs_bins)
+                            h.SetBinEdges(i, self.obs_bins)
                     h.Sumw2()
                     setattr(self, name, h)
                     getattr(self, hist_list_name).append(h)
 
                     if self.use_SD:
-
                         # SoftDrop groomed jet response matrices
                         for gl in self.grooming_labels:
-
-                            name = 'hResponse_JetPt_ang_h_%s_%s' % (label, gl)
+                            name = 'hResponse_JetPt_ang_h_%s_%sScaled' % (label, gl)
                             h = ROOT.THnF(name, name, dim, nbins_array, xmin_array, xmax_array)
                             for i in range(0, dim):
                                 h.GetAxis(i).SetTitle(title[i])
                                 if i == 0 or i == 1:
-                                    h.SetBinEdges(i, pt_bins)
+                                    h.SetBinEdges(i, self.pt_bins)
                                 else:  # i == 2 or i == 3
-                                    h.SetBinEdges(i, obs_bins)
+                                    h.SetBinEdges(i, self.obs_bins)
                             h.Sumw2()
                             setattr(self, name, h)
                             getattr(self, hist_list_name).append(h)
@@ -583,12 +647,13 @@ class pythia_parton_hadron(process_base.ProcessBase):
         for jetR in self.jetR_list:
             jetR_str = str(jetR).replace('.', '')
             
-            # Initialize tree writer
-            name = 'particle_unscaled_R%s' % jetR_str
-            t = ROOT.TTree(name, name)
-            setattr(self, "t_R%s" % jetR_str, t)
-            tw = RTreeWriter(tree=t)
-            setattr(self, "tw_R%s" % jetR_str, tw)
+            if not self.no_tree:
+                # Initialize tree writer
+                name = 'particle_unscaled_R%s' % jetR_str
+                t = ROOT.TTree(name, name)
+                setattr(self, "t_R%s" % jetR_str, t)
+                tw = RTreeWriter(tree=t)
+                setattr(self, "tw_R%s" % jetR_str, tw)
             
             # set up our jet definition and a jet selector
             jet_def = fj.JetDefinition(fj.antikt_algorithm, jetR)
@@ -683,8 +748,10 @@ class pythia_parton_hadron(process_base.ProcessBase):
             jetR_str = str(jetR).replace('.', '')
             jet_selector = getattr(self, "jet_selector_R%s" % jetR_str)
             jet_def = getattr(self, "jet_def_R%s" % jetR_str)
-            t = getattr(self, "t_R%s" % jetR_str)
-            tw = getattr(self, "tw_R%s" % jetR_str)
+            t = None; tw = None;
+            if not self.no_tree:
+                t = getattr(self, "t_R%s" % jetR_str)
+                tw = getattr(self, "tw_R%s" % jetR_str)
             count1 = getattr(self, "count1_R%s" % jetR_str)
             count2 = getattr(self, "count2_R%s" % jetR_str)
 
@@ -699,9 +766,10 @@ class pythia_parton_hadron(process_base.ProcessBase):
                 continue
 
             if self.level:  # Only save info at one level w/o matching
-                jets = locals()["jets_%s" % self.level]
-                for jet in jets:
-                    self.fill_unmatched_jet_tree(tw, jetR, iev, jet)
+                if not self.no_tree:
+                    jets = locals()["jets_%s" % self.level]
+                    for jet in jets:
+                        self.fill_unmatched_jet_tree(tw, jetR, iev, jet)
                 continue
 
             for i,jchh in enumerate(jets_ch):
@@ -733,7 +801,8 @@ class pythia_parton_hadron(process_base.ProcessBase):
                             pinfo('matched jets: ch.h:', jchh.pt(), 'h:', jh.pt(),
                                   'p:', jp.pt(), 'dr:', dr)
 
-                        self.fill_matched_jet_tree(tw, jetR, iev, jp, jh, jchh)
+                        if not self.no_tree:
+                            self.fill_matched_jet_tree(tw, jetR, iev, jp, jh, jchh)
                         self.fill_jet_histograms(jetR, jp, jh, jchh)
 
                 #print("  |-> SD jet params z={0:10.3f} dR={1:10.3f} mu={2:10.3f}".format(
@@ -815,26 +884,20 @@ class pythia_parton_hadron(process_base.ProcessBase):
     def fill_MPI_histograms(self, jetR, jet):
 
         for beta in self.beta_list:
-            label = ("R%s_%sScaled" % (str(jetR), str(beta))).replace('.', '')
-            h = getattr(self, 'hAng_JetPt_ch_MPIon_%s' % label)
+            label = ("R%s_%s" % (str(jetR), str(beta))).replace('.', '')
+            h = getattr(self, 'hAng_JetPt_ch_MPIon_%sScaled' % label)
 
             kappa = 1
             h.Fill(jet.pt(), fjext.lambda_beta_kappa(jet, beta, kappa, jetR))
 
-            ''' Need to implement these histograms in init_hist function
             if self.use_SD:
                 for i, gs in enumerate(self.grooming_settings):
                     gl = self.grooming_labels[i]
-
-                    h = getattr(self, 'hAng_JetPt_ch_MPIon_%s_%s' % (label, gl))
-
-                    # SoftDrop jets
                     gshop = fjcontrib.GroomerShop(jet, jetR, self.reclustering_algorithm)
                     jet_sd = self.utils.groom(gshop, gs, jetR).pair()
 
-                    h.Fill("l_ch_%s_%s" % (label, gl), fjext.lambda_beta_kappa(
-                        jet_sd, jet.pt(), beta, kappa, jetR))
-            '''
+                    getattr(self, 'hAng_JetPt_ch_MPIon_%s_%sScaled' % (label, gl)).Fill(
+                        jet.pt(), fjext.lambda_beta_kappa(jet, jet_sd, beta, kappa, jetR))
 
 
     #---------------------------------------------------------------
@@ -859,7 +922,8 @@ class pythia_parton_hadron(process_base.ProcessBase):
             if jp.pt():  # prevent divide by 0
                 getattr(self, 'hJetPtRes_R%s' % R_label).Fill(jp.pt(), (jp.pt() - jch.pt()) / jp.pt())
             getattr(self, 'hResponse_JetPt_R%s' % R_label).Fill(jp.pt(), jch.pt())
-            
+
+            '''
             if 60 <= jch.pt() < 80:
                 getattr(self, 'hNconstit_Pt_ch_PtBinCH60-80_R%s' % R_label).Fill(
                     jch.pt(), len(jch.constituents()))
@@ -867,6 +931,7 @@ class pythia_parton_hadron(process_base.ProcessBase):
                     jh.pt(), len(jh.constituents()))
                 getattr(self, 'hNconstit_Pt_p_PtBinCH60-80_R%s' % R_label).Fill(
                     jp.pt(), len(jp.constituents()))
+            '''
 
         # Fill angularity histograms and response matrices
         for beta in self.beta_list:
@@ -884,46 +949,78 @@ class pythia_parton_hadron(process_base.ProcessBase):
         lh = fjext.lambda_beta_kappa(jh, beta, kappa, jetR)
         lch = fjext.lambda_beta_kappa(jch, beta, kappa, jetR)
 
-        label = ("R%s_%sScaled" % (str(jetR), str(beta))).replace('.', '')
+        label = ("R%s_%s" % (str(jetR), str(beta))).replace('.', '')
 
         if self.level in [None, 'ch']:
-            getattr(self, 'hAng_JetPt_ch_%s' % label).Fill(jch.pt(), lch)
+            getattr(self, 'hAng_JetPt_ch_%sScaled' % label).Fill(jch.pt(), lch)
+            if self.use_SD:
+                for i, gs in enumerate(self.grooming_settings):
+                    gl = self.grooming_labels[i]
+                    gshop = fjcontrib.GroomerShop(jch, jetR, self.reclustering_algorithm)
+                    jch_sd = self.utils.groom(gshop, gs, jetR).pair()
+                    getattr(self, 'hAng_JetPt_ch_%s_%sScaled' % (label, gl)).Fill(
+                        jch.pt(), fjext.lambda_beta_kappa(jch, jch_sd, beta, kappa, jetR))
 
         if self.level in [None, 'h']:
-            getattr(self, 'hAng_JetPt_h_%s' % label).Fill(jh.pt(), lh)
+            getattr(self, 'hAng_JetPt_h_%sScaled' % label).Fill(jh.pt(), lh)
+            if self.use_SD:
+                for i, gs in enumerate(self.grooming_settings):
+                    gl = self.grooming_labels[i]
+                    gshop = fjcontrib.GroomerShop(jh, jetR, self.reclustering_algorithm)
+                    jh_sd = self.utils.groom(gshop, gs, jetR).pair()
+                    getattr(self, 'hAng_JetPt_h_%s_%sScaled' % (label, gl)).Fill(
+                        jh.pt(), fjext.lambda_beta_kappa(jh, jh_sd, beta, kappa, jetR))
 
         if self.level in [None, 'p']:
-            getattr(self, 'hAng_JetPt_p_%s' % label).Fill(jp.pt(), lp)
+            getattr(self, 'hAng_JetPt_p_%sScaled' % label).Fill(jp.pt(), lp)
+            if self.use_SD:
+                for i, gs in enumerate(self.grooming_settings):
+                    gl = self.grooming_labels[i]
+                    gshop = fjcontrib.GroomerShop(jp, jetR, self.reclustering_algorithm)
+                    jp_sd = self.utils.groom(gshop, gs, jetR).pair()
+                    getattr(self, 'hAng_JetPt_p_%s_%sScaled' % (label, gl)).Fill(
+                        jp.pt(), fjext.lambda_beta_kappa(jp, jp_sd, beta, kappa, jetR))
 
         if self.level == None:
-            getattr(self, 'hResponse_ang_%s' % label).Fill(lp, lch)
+            getattr(self, 'hResponse_ang_%sScaled' % label).Fill(lp, lch)
+            if self.use_SD:
+                for i, gs in enumerate(self.grooming_settings):
+                    gl = self.grooming_labels[i]
+                    gshop_p = fjcontrib.GroomerShop(jp, jetR, self.reclustering_algorithm)
+                    jp_sd = self.utils.groom(gshop_p, gs, jetR).pair()
+                    gshop_ch = fjcontrib.GroomerShop(jp, jetR, self.reclustering_algorithm)
+                    jch_sd = self.utils.groom(gshop_ch, gs, jetR).pair()
+                    getattr(self, 'hResponse_ang_%s_%sScaled' % (label, gl)).Fill(
+                        fjext.lambda_beta_kappa(jp, jp_sd, beta, kappa, jetR), \
+                        fjext.lambda_beta_kappa(jch, jch_sd, beta, kappa, jetR))
 
+            '''
             # Lambda at p-vs-ch-level for various bins in ch jet pT 
             if 20 <= jch.pt() < 40:
-                getattr(self, 'hResponse_ang_PtBinCH20-40_%s' % label).Fill(lp, lch)
+                getattr(self, 'hResponse_ang_PtBinCH20-40_%sScaled' % label).Fill(lp, lch)
             elif 40 <= jch.pt() < 60:
-                getattr(self, 'hResponse_ang_PtBinCH40-60_%s' % label).Fill(lp, lch)
+                getattr(self, 'hResponse_ang_PtBinCH40-60_%sScaled' % label).Fill(lp, lch)
             elif 60 <= jch.pt() < 80:
-                getattr(self, 'hResponse_ang_PtBinCH60-80_%s' % label).Fill(lp, lch)
+                getattr(self, 'hResponse_ang_PtBinCH60-80_%sScaled' % label).Fill(lp, lch)
 
             # Phase space plots and annulus histograms, including those binned in ch jet pT
             num_r = self.annulus_plots_num_r
             ang_per_r_ch = [0] * num_r
             for particle in jch.constituents():
                 deltaR = particle.delta_R(jch)
-                getattr(self, 'hPhaseSpace_DeltaR_Pt_ch_%s' % label).Fill(
+                getattr(self, 'hPhaseSpace_DeltaR_Pt_ch_%sScaled' % label).Fill(
                     particle.pt(), deltaR / jetR)
 
                 lambda_i = lambda_beta_kappa_i(particle, jch, jetR, beta, 1)
-                getattr(self, 'hPhaseSpace_ang_DeltaR_ch_%s' % label).Fill(deltaR / jetR, lambda_i)
-                getattr(self, 'hPhaseSpace_ang_Pt_ch_%s' % label).Fill(particle.pt(), lambda_i)
+                getattr(self, 'hPhaseSpace_ang_DeltaR_ch_%sScaled' % label).Fill(deltaR / jetR, lambda_i)
+                getattr(self, 'hPhaseSpace_ang_Pt_ch_%sScaled' % label).Fill(particle.pt(), lambda_i)
 
                 if 60 <= jch.pt() < 80:
-                    getattr(self, 'hPhaseSpace_DeltaR_Pt_ch_PtBinCH60-80_%s' % label).Fill(
+                    getattr(self, 'hPhaseSpace_DeltaR_Pt_ch_PtBinCH60-80_%sScaled' % label).Fill(
                         particle.pt(), deltaR / jetR)
-                    getattr(self, 'hPhaseSpace_ang_DeltaR_ch_PtBinCH60-80_%s' % label).Fill(
+                    getattr(self, 'hPhaseSpace_ang_DeltaR_ch_PtBinCH60-80_%sScaled' % label).Fill(
                         deltaR / jetR, lambda_i)
-                    getattr(self, 'hPhaseSpace_ang_Pt_ch_PtBinCH60-80_%s' % label).Fill(
+                    getattr(self, 'hPhaseSpace_ang_Pt_ch_PtBinCH60-80_%sScaled' % label).Fill(
                         particle.pt(), lambda_i)
 
                 ang_per_r_ch = [ang_per_r_ch[i] + lambda_i * 
@@ -933,19 +1030,19 @@ class pythia_parton_hadron(process_base.ProcessBase):
             ang_per_r_p = [0] * num_r
             for particle in jp.constituents():
                 deltaR = particle.delta_R(jp)
-                getattr(self, 'hPhaseSpace_DeltaR_Pt_p_%s' % label).Fill(
+                getattr(self, 'hPhaseSpace_DeltaR_Pt_p_%sScaled' % label).Fill(
                     particle.pt(), deltaR / jetR)
 
                 lambda_i = lambda_beta_kappa_i(particle, jp, jetR, beta, 1)
-                getattr(self, 'hPhaseSpace_ang_DeltaR_p_%s' % label).Fill(deltaR / jetR, lambda_i)
-                getattr(self, 'hPhaseSpace_ang_Pt_p_%s' % label).Fill(particle.pt(), lambda_i)
+                getattr(self, 'hPhaseSpace_ang_DeltaR_p_%sScaled' % label).Fill(deltaR / jetR, lambda_i)
+                getattr(self, 'hPhaseSpace_ang_Pt_p_%sScaled' % label).Fill(particle.pt(), lambda_i)
 
                 if 60 <= jch.pt() < 80:
-                    getattr(self, 'hPhaseSpace_DeltaR_Pt_p_PtBinCH60-80_%s' % label).Fill(
+                    getattr(self, 'hPhaseSpace_DeltaR_Pt_p_PtBinCH60-80_%sScaled' % label).Fill(
                         particle.pt(), deltaR / jetR)
-                    getattr(self, 'hPhaseSpace_ang_DeltaR_p_PtBinCH60-80_%s' % label).Fill(
+                    getattr(self, 'hPhaseSpace_ang_DeltaR_p_PtBinCH60-80_%sScaled' % label).Fill(
                         deltaR / jetR, lambda_i)
-                    getattr(self, 'hPhaseSpace_ang_Pt_p_PtBinCH60-80_%s' % label).Fill(
+                    getattr(self, 'hPhaseSpace_ang_Pt_p_PtBinCH60-80_%sScaled' % label).Fill(
                         particle.pt(), lambda_i)
 
                 ang_per_r_p = [ang_per_r_p[i] + lambda_i *
@@ -953,29 +1050,30 @@ class pythia_parton_hadron(process_base.ProcessBase):
                              for i in range(0, num_r, 1)]
 
             for i in range(0, num_r, 1):
-                getattr(self, 'hAnnulus_ang_p_%s' % label).Fill(
+                getattr(self, 'hAnnulus_ang_p_%sScaled' % label).Fill(
                     (i+1) * self.annulus_plots_max_x / num_r, ang_per_r_p[i] / (lp + 1e-11))
-                getattr(self, 'hAnnulus_ang_ch_%s' % label).Fill(
+                getattr(self, 'hAnnulus_ang_ch_%sScaled' % label).Fill(
                     (i+1) * self.annulus_plots_max_x / num_r, ang_per_r_ch[i] / (lch + 1e-11))
                 if 60 <= jch.pt() < 80:
-                    getattr(self, 'hAnnulus_ang_p_PtBinCH60-80_%s' % label).Fill(
+                    getattr(self, 'hAnnulus_ang_p_PtBinCH60-80_%sScaled' % label).Fill(
                         (i+1) * self.annulus_plots_max_x / num_r, ang_per_r_p[i] / (lp + 1e-11))
-                    getattr(self, 'hAnnulus_ang_ch_PtBinCH60-80_%s' % label).Fill(
+                    getattr(self, 'hAnnulus_ang_ch_PtBinCH60-80_%sScaled' % label).Fill(
                         (i+1) * self.annulus_plots_max_x / num_r, ang_per_r_ch[i] / (lch + 1e-11))
+            '''
 
             # Residual plots (with and without divisor in y-axis)
-            getattr(self, "hAngDiff_JetPt_%s" % label).Fill(jch.pt(), lp - lch)
+            getattr(self, "hAngDiff_JetPt_%sScaled" % label).Fill(jch.pt(), lp - lch)
             if lp:  # prevent divide by 0
-                getattr(self, "hAngResidual_JetPt_%s" % label).Fill(jp.pt(), (lp - lch) / lp)
+                getattr(self, "hAngResidual_JetPt_%sScaled" % label).Fill(jp.pt(), (lp - lch) / lp)
 
             # 4D response matrices for "forward folding" to ch level
             x = ([jch.pt(), jp.pt(), lch, lp])
             x_array = array('d', x)
-            getattr(self, 'hResponse_JetPt_ang_ch_%s' % label).Fill(x_array)
+            getattr(self, 'hResponse_JetPt_ang_ch_%sScaled' % label).Fill(x_array)
 
             x = ([jh.pt(), jp.pt(), lh, lp])
             x_array = array('d', x)
-            getattr(self, 'hResponse_JetPt_ang_h_%s' % label).Fill(x_array)
+            getattr(self, 'hResponse_JetPt_ang_h_%sScaled' % label).Fill(x_array)
 
             if self.use_SD:
                 for i, gs in enumerate(self.grooming_settings):
@@ -994,11 +1092,11 @@ class pythia_parton_hadron(process_base.ProcessBase):
 
                     x = ([jch.pt(), jp.pt(), lch_sd, lp_sd])
                     x_array = array('d', x)
-                    getattr(self, 'hResponse_JetPt_ang_ch_%s_%s' % (label, gl)).Fill(x_array)
+                    getattr(self, 'hResponse_JetPt_ang_ch_%s_%sScaled' % (label, gl)).Fill(x_array)
 
                     x = ([jh.pt(), jp.pt(), lh, lp])
                     x_array = array('d', x)
-                    getattr(self, 'hResponse_JetPt_ang_h_%s_%s' % (label, gl)).Fill(x_array)
+                    getattr(self, 'hResponse_JetPt_ang_h_%s_%sScaled' % (label, gl)).Fill(x_array)
 
 
     #---------------------------------------------------------------
@@ -1010,9 +1108,9 @@ class pythia_parton_hadron(process_base.ProcessBase):
         # and the number of accepted events
         if not self.no_scale:
             scale_f = pythia.info.sigmaGen() / self.hNevents.GetBinContent(1)
-            print("Weight MPIoff tree by (cross section)/(N events) =", scale_f)
+            print("Weight MPIoff histograms by (cross section)/(N events) =", scale_f)
             MPI_scale_f = pythia_MPI.info.sigmaGen() / self.hNeventsMPI.GetBinContent(1)
-            print("Weight MPIon tree by (cross section)/(N events) =", MPI_scale_f)
+            print("Weight MPIon histograms by (cross section)/(N events) =", MPI_scale_f)
             self.scale_jet_histograms(scale_f, MPI_scale_f)
         print()
 
@@ -1041,9 +1139,9 @@ class pythia_parton_hadron(process_base.ProcessBase):
             for h in getattr(self, hist_list_name):
                 h.Scale(scale_f)
 
-            for beta in self.beta_list:
-                label = ("R%s_%sScaled" % (str(jetR), str(beta))).replace('.', '')
-                getattr(self, 'hAng_JetPt_ch_MPIon_%s' % label).Scale(MPI_scale_f)
+            hist_list_MPIon_name = "hist_list_MPIon_R%s" % str(jetR).replace('.', '')
+            for h in getattr(self, hist_list_MPIon_name):
+                h.Scale(MPI_scale_f)
 
 
 ################################################################
@@ -1057,6 +1155,8 @@ if __name__ == '__main__':
                         help='Output directory for generated ROOT file(s)')
     parser.add_argument('--tree-output-fname', default="AnalysisResults.root", type=str,
                         help="Filename for the (unscaled) generated particle ROOT TTree")
+    parser.add_argument('--no-tree', default=False, action='store_true', 
+                        help="Do not save tree of particle information, only create histograms")
     parser.add_argument('--no-match-level', help="Save simulation for only one level with " + \
                         "no matching. Options: 'p', 'h', 'ch'", default=None, type=str)
     parser.add_argument('--no-scale', help="Turn off rescaling all histograms by cross section / N",

--- a/pyjetty/alice_analysis/process/user/ang_pp/pythia_parton_hadron.py
+++ b/pyjetty/alice_analysis/process/user/ang_pp/pythia_parton_hadron.py
@@ -221,7 +221,7 @@ class pythia_parton_hadron(process_base.ProcessBase):
 
                 name = 'hResponse_JetPt_R%s' % R_label
                 h = ROOT.TH2F(name, name, 200, 0, 200, 200, 0, 200)
-                h.GetXaxis().SetTitle('#it{p}_{T}^{parotn jet}')
+                h.GetXaxis().SetTitle('#it{p}_{T}^{parton jet}')
                 h.GetYaxis().SetTitle('#it{p}_{T}^{ch jet}')
                 h.Sumw2()
                 setattr(self, name, h)
@@ -638,6 +638,37 @@ class pythia_parton_hadron(process_base.ProcessBase):
                             setattr(self, name, h)
                             getattr(self, hist_list_name).append(h)
 
+                    # Finally, a set of THn for folding H --> CH (with MPI on)
+                    title = ['p_{T}^{ch jet}', 'p_{T}^{h jet}', 
+                             '#lambda_{#beta}^{ch}', '#lambda_{#beta}^{h}']
+
+                    name = 'hResponse_JetPt_ang_Fnp_%sScaled' % label
+                    h = ROOT.THnF(name, name, dim, nbins_array, xmin_array, xmax_array)
+                    for i in range(0, dim):
+                        h.GetAxis(i).SetTitle(title[i])
+                        if i == 0 or i == 1:
+                            h.SetBinEdges(i, self.pt_bins)
+                        else:  # i == 2 or i == 3
+                            h.SetBinEdges(i, self.obs_bins)
+                    h.Sumw2()
+                    setattr(self, name, h)
+                    getattr(self, hist_list_name_MPIon).append(h)
+
+                    if self.use_SD:
+                        # SoftDrop groomed jet response matrices
+                        for gl in self.grooming_labels:
+                            name = 'hResponse_JetPt_ang_Fnp_%s_%sScaled' % (label, gl)
+                            h = ROOT.THnF(name, name, dim, nbins_array, xmin_array, xmax_array)
+                            for i in range(0, dim):
+                                h.GetAxis(i).SetTitle(title[i])
+                                if i == 0 or i == 1:
+                                    h.SetBinEdges(i, self.pt_bins)
+                                else:  # i == 2 or i == 3
+                                    h.SetBinEdges(i, self.obs_bins)
+                            h.Sumw2()
+                            setattr(self, name, h)
+                            getattr(self, hist_list_name_MPIon).append(h)
+
 
     #---------------------------------------------------------------
     # Initiate jet defs, selectors, and sd (if required)
@@ -763,9 +794,8 @@ class pythia_parton_hadron(process_base.ProcessBase):
             if MPIon:
                 for jet in jets_ch:
                     self.fill_MPI_histograms(jetR, jet)
-                continue
 
-            if self.level:  # Only save info at one level w/o matching
+            if self.level and not MPIon:  # Only save info at one level w/o matching
                 if not self.no_tree:
                     jets = locals()["jets_%s" % self.level]
                     for jet in jets:
@@ -801,15 +831,23 @@ class pythia_parton_hadron(process_base.ProcessBase):
                             pinfo('matched jets: ch.h:', jchh.pt(), 'h:', jh.pt(),
                                   'p:', jp.pt(), 'dr:', dr)
 
-                        if not self.no_tree:
-                            self.fill_matched_jet_tree(tw, jetR, iev, jp, jh, jchh)
-                        self.fill_jet_histograms(jetR, jp, jh, jchh)
+                        if not MPIon:
+                            self.fill_jet_histograms(jetR, jp, jh, jchh)
+                            if not self.no_tree:
+                                self.fill_matched_jet_tree(tw, jetR, iev, jp, jh, jchh)
+                        else:
+                            self.fill_jet_histograms_MPI(jetR, jp, jh, jchh)
 
                 #print("  |-> SD jet params z={0:10.3f} dR={1:10.3f} mu={2:10.3f}".format(
                 #    sd_info.z, sd_info.dR, sd_info.mu))
 
-            setattr(self, "count1_R%s" % jetR_str, count1)
-            setattr(self, "count2_R%s" % jetR_str, count2)
+            if MPIon:
+                setattr(self, "count1_R%s_MPIon" % jetR_str, count1)
+                setattr(self, "count2_R%s_MPIon" % jetR_str, count2)
+            else:
+                setattr(self, "count1_R%s" % jetR_str, count1)
+                setattr(self, "count2_R%s" % jetR_str, count2)
+
 
     #---------------------------------------------------------------
     # Fill jet tree with (unscaled/raw) matched parton/hadron tracks
@@ -1097,6 +1135,42 @@ class pythia_parton_hadron(process_base.ProcessBase):
                     x = ([jh.pt(), jp.pt(), lh, lp])
                     x_array = array('d', x)
                     getattr(self, 'hResponse_JetPt_ang_h_%s_%sScaled' % (label, gl)).Fill(x_array)
+
+
+    #---------------------------------------------------------------
+    # Fill jet histograms for MPI (which are just the H-->CH RMs)
+    #---------------------------------------------------------------
+    def fill_jet_histograms_MPI(self, jetR, jp, jh, jch):
+
+        for beta in self.beta_list:
+
+            # Calculate angularities
+            kappa = 1
+            lh = fjext.lambda_beta_kappa(jh, beta, kappa, jetR)
+            lch = fjext.lambda_beta_kappa(jch, beta, kappa, jetR)
+
+            label = ("R%s_%s" % (str(jetR), str(beta))).replace('.', '')
+
+            # 4D response matrices for "forward folding" from h to ch level
+            x = ([jch.pt(), jh.pt(), lch, lh])
+            x_array = array('d', x)
+            getattr(self, 'hResponse_JetPt_ang_Fnp_%sScaled' % label).Fill(x_array)
+
+            if self.use_SD:
+                for i, gs in enumerate(self.grooming_settings):
+                    gl = self.grooming_labels[i]
+
+                    # SoftDrop jet angularities
+                    gshop_ch = fjcontrib.GroomerShop(jch, jetR, self.reclustering_algorithm)
+                    jet_sd_ch = self.utils.groom(gshop_ch, gs, jetR).pair()
+                    lch_sd = fjext.lambda_beta_kappa(jch, jet_sd_ch, beta, kappa, jetR)
+                    gshop_h = fjcontrib.GroomerShop(jh, jetR, self.reclustering_algorithm)
+                    jet_sd_h = self.utils.groom(gshop_h, gs, jetR).pair()
+                    lh_sd = fjext.lambda_beta_kappa(jh, jet_sd_h, beta, kappa, jetR)
+
+                    x = ([jch.pt(), jh.pt(), lch_sd, lh_sd])
+                    x_array = array('d', x)
+                    getattr(self, 'hResponse_JetPt_ang_Fnp_%s_%sScaled' % (label, gl)).Fill(x_array)
 
 
     #---------------------------------------------------------------

--- a/pyjetty/alice_analysis/slurm/sbatch/ang/ang_LHC18b8.sh
+++ b/pyjetty/alice_analysis/slurm/sbatch/ang/ang_LHC18b8.sh
@@ -29,7 +29,7 @@ fi
 # Define output path from relevant sub-path of input file
 OUTPUT_PREFIX="AnalysisResults/ang/$JOB_ID"
 # Note: depends on file structure of input file -- need to edit appropriately for each dataset
-OUTPUT_SUFFIX=$(echo $INPUT_FILE | cut -d/ -f6-11)
+OUTPUT_SUFFIX=$(echo $INPUT_FILE | cut -d/ -f6-10)
 #echo $OUTPUT_SUFFIX
 OUTPUT_DIR="/rstorage/alice/$OUTPUT_PREFIX/$OUTPUT_SUFFIX"
 mkdir -p $OUTPUT_DIR

--- a/pyjetty/alice_analysis/slurm/sbatch/ang/ang_slurm_LHC18b8.sh
+++ b/pyjetty/alice_analysis/slurm/sbatch/ang/ang_slurm_LHC18b8.sh
@@ -7,7 +7,7 @@
 #SBATCH --array=1-640
 #SBATCH --output=/rstorage/alice/AnalysisResults/ang/slurm-%A_%a.out
 
-FILE_PATHS='/rstorage/alice/data/LHC18b8/520/files.txt'
+FILE_PATHS='/rstorage/alice/data/LHC18b8/569/files.txt'
 NFILES=$(wc -l < $FILE_PATHS)
 echo "N files to process: ${NFILES}"
 

--- a/pyjetty/alice_analysis/slurm/sbatch/ang/gen/herwig_ang_slurm.sh
+++ b/pyjetty/alice_analysis/slurm/sbatch/ang/gen/herwig_ang_slurm.sh
@@ -4,18 +4,18 @@
 #SBATCH --nodes=1 --ntasks=1 --cpus-per-task=1
 #SBATCH --partition=std
 #SBATCH --time=24:00:00
-#SBATCH --array=1-1000
+#SBATCH --array=1-3000
 #SBATCH --output=/rstorage/alice/AnalysisResults/ang/slurm-%A_%a.out
 
 # Number of events per pT-hat bin (for statistics)
-NEV_DESIRED=5000000
+NEV_DESIRED=15000000
 
 # Lower edges of the pT-hat bins
 PTHAT_BINS=(7 9 12 16 21 28 36 45 57 70 85 99 115 132 150 169 190 212 235 260)
 echo "Number of pT-hat bins: ${#PTHAT_BINS[@]}"
 
 # Currently we have 8 nodes * 20 cores active
-NCORES=1000
+NCORES=3000
 NEV_PER_JOB=$(( $NEV_DESIRED * ${#PTHAT_BINS[@]} / $NCORES ))
 echo "Number of events per job: $NEV_PER_JOB"
 NCORES_PER_BIN=$(( $NCORES / ${#PTHAT_BINS[@]} ))

--- a/pyjetty/alice_analysis/slurm/sbatch/ang/gen/herwig_ang_slurm.sh
+++ b/pyjetty/alice_analysis/slurm/sbatch/ang/gen/herwig_ang_slurm.sh
@@ -58,7 +58,7 @@ module use ~/pyjetty/modules
 module load pyjetty/1.0
 echo "python is" $(which python)
 cd /home/ezra/analysis_env/
-pipenv run python $PYTHON_SCRIPT -c $CONFIG --input-file $TEMP_OUTDIR/LHC_5020-S$SEED.log --input-file-mpi $TEMP_OUTDIR/LHC_5020_MPI-S$SEED.log --output-dir $OUTDIR
+pipenv run python $PYTHON_SCRIPT -c $CONFIG --input-file $TEMP_OUTDIR/LHC_5020-S$SEED.log --input-file-mpi $TEMP_OUTDIR/LHC_5020_MPI-S$SEED.log --output-dir $OUTDIR --no-tree
 
 # Clean up Herwig7 files to save space
 rm $TEMP_OUTDIR/LHC_5020-S$SEED.*

--- a/pyjetty/alice_analysis/slurm/sbatch/ang/gen/pythia_ang_slurm.sh
+++ b/pyjetty/alice_analysis/slurm/sbatch/ang/gen/pythia_ang_slurm.sh
@@ -53,10 +53,10 @@ CONFIG="/home/ezra/pyjetty/pyjetty/alice_analysis/config/ang/gen_angularity.yaml
 if $USE_PTHAT_MAX; then
 	echo "pipenv run python $SCRIPT -c $CONFIG --output-dir $OUTDIR --user-seed $SEED --py-pthatmin $PTHAT_MIN --py-ecm $ECM --nev $NEV_PER_JOB --pythiaopts HardQCD:all=on,TimeShower:pTmin=0.2,PhaseSpace:pTHatMax=$PTHAT_MAX "
 	pipenv run python $SCRIPT -c $CONFIG --output-dir $OUTDIR --user-seed $SEED \
-		--py-pthatmin $PTHAT_MIN --py-ecm $ECM --nev $NEV_PER_JOB \
+		--py-pthatmin $PTHAT_MIN --py-ecm $ECM --nev $NEV_PER_JOB --no-tree \
 		--pythiaopts HardQCD:all=on,TimeShower:pTmin=0.2,PhaseSpace:pTHatMax=$PTHAT_MAX 
 else
 	pipenv run python $SCRIPT -c $CONFIG --output-dir $OUTDIR \
 		--user-seed $SEED --py-pthatmin $PTHAT_MIN --py-ecm $ECM --nev $NEV_PER_JOB \
-		--pythiaopts HardQCD:all=on,TimeShower:pTmin=0.2
+		--no-tree --pythiaopts HardQCD:all=on,TimeShower:pTmin=0.2
 fi

--- a/pyjetty/alice_analysis/slurm/sbatch/ang/gen/pythia_ang_slurm.sh
+++ b/pyjetty/alice_analysis/slurm/sbatch/ang/gen/pythia_ang_slurm.sh
@@ -4,21 +4,21 @@
 #SBATCH --nodes=1 --ntasks=1 --cpus-per-task=1
 #SBATCH --partition=std
 #SBATCH --time=24:00:00
-#SBATCH --array=1-280
+#SBATCH --array=1-1120
 #SBATCH --output=/rstorage/alice/AnalysisResults/ang/slurm-%A_%a.out
 
 # Center of mass energy in GeV
 ECM=5020
 
 # Number of events per pT-hat bin (for statistics)
-NEV_DESIRED=7000000
+NEV_DESIRED=21000000
 
 # Lower edges of the pT-hat bins
 PTHAT_BINS=(5 7 9 12 16 21 28 36 45 57 70 85 99 115 132 150 169 190 212 235)
 echo "Number of pT-hat bins: ${#PTHAT_BINS[@]}"
 
 # Currently we have 8 nodes * 20 cores active
-NCORES=280
+NCORES=1120
 NEV_PER_JOB=$(( $NEV_DESIRED * ${#PTHAT_BINS[@]} / $NCORES ))
 echo "Number of events per job: $NEV_PER_JOB"
 NCORES_PER_BIN=$(( $NCORES / ${#PTHAT_BINS[@]} ))

--- a/pyjetty/alice_analysis/slurm/sbatch/ang/randmass/ang_LHC18b8_randmass.sh
+++ b/pyjetty/alice_analysis/slurm/sbatch/ang/randmass/ang_LHC18b8_randmass.sh
@@ -29,7 +29,7 @@ fi
 # Define output path from relevant sub-path of input file
 OUTPUT_PREFIX="AnalysisResults/ang/$JOB_ID"
 # Note: depends on file structure of input file -- need to edit appropriately for each dataset
-OUTPUT_SUFFIX=$(echo $INPUT_FILE | cut -d/ -f6-11)
+OUTPUT_SUFFIX=$(echo $INPUT_FILE | cut -d/ -f6-10)
 #echo $OUTPUT_SUFFIX
 OUTPUT_DIR="/rstorage/alice/$OUTPUT_PREFIX/$OUTPUT_SUFFIX"
 mkdir -p $OUTPUT_DIR

--- a/pyjetty/alice_analysis/slurm/sbatch/ang/randmass/ang_slurm_LHC18b8_randmass.sh
+++ b/pyjetty/alice_analysis/slurm/sbatch/ang/randmass/ang_slurm_LHC18b8_randmass.sh
@@ -7,7 +7,7 @@
 #SBATCH --array=1-640
 #SBATCH --output=/rstorage/alice/AnalysisResults/ang/slurm-%A_%a.out
 
-FILE_PATHS='/rstorage/alice/data/LHC18b8/520/files.txt'
+FILE_PATHS='/rstorage/alice/data/LHC18b8/569/files.txt'
 NFILES=$(wc -l < $FILE_PATHS)
 echo "N files to process: ${NFILES}"
 

--- a/pyjetty/alice_analysis/slurm/sbatch/ang/treff/ang_LHC18b8_treff.sh
+++ b/pyjetty/alice_analysis/slurm/sbatch/ang/treff/ang_LHC18b8_treff.sh
@@ -29,7 +29,7 @@ fi
 # Define output path from relevant sub-path of input file
 OUTPUT_PREFIX="AnalysisResults/ang/$JOB_ID"
 # Note: depends on file structure of input file -- need to edit appropriately for each dataset
-OUTPUT_SUFFIX=$(echo $INPUT_FILE | cut -d/ -f6-11)
+OUTPUT_SUFFIX=$(echo $INPUT_FILE | cut -d/ -f6-10)
 #echo $OUTPUT_SUFFIX
 OUTPUT_DIR="/rstorage/alice/$OUTPUT_PREFIX/$OUTPUT_SUFFIX"
 mkdir -p $OUTPUT_DIR

--- a/pyjetty/alice_analysis/slurm/sbatch/ang/treff/ang_slurm_LHC18b8_treff.sh
+++ b/pyjetty/alice_analysis/slurm/sbatch/ang/treff/ang_slurm_LHC18b8_treff.sh
@@ -7,7 +7,7 @@
 #SBATCH --array=1-640
 #SBATCH --output=/rstorage/alice/AnalysisResults/ang/slurm-%A_%a.out
 
-FILE_PATHS='/rstorage/alice/data/LHC18b8/520/files.txt'
+FILE_PATHS='/rstorage/alice/data/LHC18b8/569/files.txt'
 NFILES=$(wc -l < $FILE_PATHS)
 echo "N files to process: ${NFILES}"
 

--- a/pyjetty/alice_analysis/slurm/utils/ang/gen/merge_herwig.sh
+++ b/pyjetty/alice_analysis/slurm/utils/ang/gen/merge_herwig.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 # Script to merge output ROOT files
-JOB_ID=225271
+JOB_ID=344912
 OUTPUT_DIR="/rstorage/alice/AnalysisResults/ang/$JOB_ID"
 
 # command line arguments

--- a/pyjetty/alice_analysis/slurm/utils/ang/gen/merge_herwig.sh
+++ b/pyjetty/alice_analysis/slurm/utils/ang/gen/merge_herwig.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 # Script to merge output ROOT files
-JOB_ID=353739
+JOB_ID=353890
 OUTPUT_DIR="/rstorage/alice/AnalysisResults/ang/$JOB_ID"
 
 # command line arguments

--- a/pyjetty/alice_analysis/slurm/utils/ang/gen/merge_herwig.sh
+++ b/pyjetty/alice_analysis/slurm/utils/ang/gen/merge_herwig.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 # Script to merge output ROOT files
-JOB_ID=344912
+JOB_ID=353739
 OUTPUT_DIR="/rstorage/alice/AnalysisResults/ang/$JOB_ID"
 
 # command line arguments

--- a/pyjetty/alice_analysis/slurm/utils/ang/gen/merge_pythia.sh
+++ b/pyjetty/alice_analysis/slurm/utils/ang/gen/merge_pythia.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 # Script to merge output ROOT files
-JOB_ID=353738
+JOB_ID=353823
 OUTPUT_DIR="/rstorage/alice/AnalysisResults/ang/$JOB_ID"
 
 # command line arguments

--- a/pyjetty/alice_analysis/slurm/utils/ang/gen/merge_pythia.sh
+++ b/pyjetty/alice_analysis/slurm/utils/ang/gen/merge_pythia.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 # Script to merge output ROOT files
-JOB_ID=196181
+JOB_ID=312661
 OUTPUT_DIR="/rstorage/alice/AnalysisResults/ang/$JOB_ID"
 
 # command line arguments

--- a/pyjetty/alice_analysis/slurm/utils/ang/gen/merge_pythia.sh
+++ b/pyjetty/alice_analysis/slurm/utils/ang/gen/merge_pythia.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 # Script to merge output ROOT files
-JOB_ID=312661
+JOB_ID=344810
 OUTPUT_DIR="/rstorage/alice/AnalysisResults/ang/$JOB_ID"
 
 # command line arguments

--- a/pyjetty/alice_analysis/slurm/utils/ang/gen/merge_pythia.sh
+++ b/pyjetty/alice_analysis/slurm/utils/ang/gen/merge_pythia.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 # Script to merge output ROOT files
-JOB_ID=344810
+JOB_ID=353738
 OUTPUT_DIR="/rstorage/alice/AnalysisResults/ang/$JOB_ID"
 
 # command line arguments

--- a/pyjetty/alice_analysis/slurm/utils/ang/merge_LHC18b8.sh
+++ b/pyjetty/alice_analysis/slurm/utils/ang/merge_LHC18b8.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 # Script to merge output ROOT files
-JOB_ID=287381
+JOB_ID=351487
 OUTPUT_DIR="/rstorage/alice/AnalysisResults/ang/$JOB_ID"
 
 # command line arguments
@@ -28,7 +28,8 @@ module list
 
 # Merge all output files from each pt-hat bin
 FILE_DIR_BASE=/rstorage/alice/AnalysisResults/ang/$JOB_ID
-FILES=$( find ${FILE_DIR_BASE}/520/child_*/TrainOutput/${BIN}/ -name "*.root" )
+FILES=$( find ${FILE_DIR_BASE}/569/LHC18b8_*/${BIN}/ -name "*.root" )
+#FILES=$( find ${FILE_DIR_BASE}/520/child_*/TrainOutput/${BIN}/ -name "*.root" )
 #FILES=$( find ${FILE_DIR_BASE}/260023/${BIN}/ -name "*.root" )
 
 OUT_DIR_BASE=/rstorage/alice/AnalysisResults/ang/$JOB_ID

--- a/pyjetty/alice_analysis/slurm/utils/ang/randmass/merge_LHC18b8_randmass.sh
+++ b/pyjetty/alice_analysis/slurm/utils/ang/randmass/merge_LHC18b8_randmass.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 # Script to merge output ROOT files
-JOB_ID=287384
+JOB_ID=351488
 OUTPUT_DIR="/rstorage/alice/AnalysisResults/ang/$JOB_ID"
 
 # command line arguments
@@ -28,7 +28,8 @@ module list
 
 # Merge all output files from each pt-hat bin
 FILE_DIR_BASE=/rstorage/alice/AnalysisResults/ang/$JOB_ID
-FILES=$( find ${FILE_DIR_BASE}/520/child_*/TrainOutput/${BIN}/ -name "*.root" )
+FILES=$( find ${FILE_DIR_BASE}/569/LHC18b8_*/${BIN}/ -name "*.root" )
+#FILES=$( find ${FILE_DIR_BASE}/520/child_*/TrainOutput/${BIN}/ -name "*.root" )
 #FILES=$( find ${FILE_DIR_BASE}/260023/${BIN}/ -name "*.root" )
 
 OUT_DIR_BASE=/rstorage/alice/AnalysisResults/ang/$JOB_ID

--- a/pyjetty/alice_analysis/slurm/utils/ang/treff/merge_LHC18b8_treff.sh
+++ b/pyjetty/alice_analysis/slurm/utils/ang/treff/merge_LHC18b8_treff.sh
@@ -28,7 +28,8 @@ module list
 
 # Merge all output files from each pt-hat bin
 FILE_DIR_BASE=/rstorage/alice/AnalysisResults/ang/$JOB_ID
-FILES=$( find ${FILE_DIR_BASE}/520/child_*/TrainOutput/${BIN}/ -name "*.root" )
+FILES=$( find ${FILE_DIR_BASE}/569/LHC18b8_*/${BIN}/ -name "*.root" )
+#FILES=$( find ${FILE_DIR_BASE}/520/child_*/TrainOutput/${BIN}/ -name "*.root" )
 #FILES=$( find ${FILE_DIR_BASE}/260023/${BIN}/ -name "*.root" )
 
 OUT_DIR_BASE=/rstorage/alice/AnalysisResults/ang/$JOB_ID

--- a/pyjetty/alice_analysis/slurm/utils/ang/treff/merge_LHC18b8_treff.sh
+++ b/pyjetty/alice_analysis/slurm/utils/ang/treff/merge_LHC18b8_treff.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 # Script to merge output ROOT files
-JOB_ID=287382
+JOB_ID=351489
 OUTPUT_DIR="/rstorage/alice/AnalysisResults/ang/$JOB_ID"
 
 # command line arguments


### PR DESCRIPTION
Adding code to do F_np shape function convolution for the ungroomed jet angularities. Groomed case has not yet been tested and is disabled for the time being. 

Also added/corrected folding procedure for groomed angularities (with no F_np). This is technically working, but should be tested further before believing results...