### PR TITLE
Fix shift in tree entries when initialized with empty array

### DIFF
--- a/pyjetty/mputils/treewriter.py
+++ b/pyjetty/mputils/treewriter.py
@@ -47,7 +47,7 @@ class RTreeWriter(MPBase):
 			print('[i] RTreeWriter {} tree {}: creating branch [{}]'.format(self.name, self.tree.GetName(), bname))
 			self.branch_containers[bname] = ROOT.std.vector('float')()
 			b = self.tree.Branch(bname, self.branch_containers[bname])
-		if b:
+		if b and value != []:
 			# print('filling branch:', bname, 'at', b)
 			self.branch_containers[bname].push_back(value)
 
@@ -67,6 +67,9 @@ class RTreeWriter(MPBase):
 			self._fill_branch(bname, value)
 			return
 		if type(value) in [tuple, list, self._fj_psj_vector_type]:
+			if not value:
+				self._fill_branch(bname, [])
+				return
 			if do_enumerate:
 				r = [self.fill_branch('{}_{}'.format(bname, i), x) for i,x in enumerate(value)]
 			else:


### PR DESCRIPTION
There was a problem when not all branches are created at the same time – in such a situation a shift between corresponding values is introduced, see minimal working example below.

I see two issues:
1. not sure what should be done about empty iterables of other types (like dict) – so far nothing
2. this is low-code fix, but a special case in `_fill_branch()` is effecively created: if `value` is empty list then branch is created but not filled. Maybe one should split it into `_create_branch()` and `_fill_branch()`?


```
import numpy as np
import pandas as pd
import uproot
from pprint import pprint
from pyjetty.mputils import treewriter

def fill(tw, dummy_value, n_elem):
    tw.fill_branch('single', dummy_value)
    tw.fill_branch('array', [dummy_value+i for i in range(n_elem)])
    tw.fill_tree()

tw = treewriter.RTreeWriter(name ='t', file_name='test.root')

### SUCCESS:
# fill(tw, 100, 5)
# fill(tw, 10, 0)
# fill(tw, -1, 3)

### FAIL:
fill(tw, 10, 0)     # 'array' init with empty list – branch is not created
fill(tw, 100, 5)  
fill(tw, -1, 3)

tw.write_and_close()

print('file saved, check results:')
froot = uproot.open("test.root")
t = froot.get("tt")
arr = t.arrays(library="np")
try:
    df = pd.DataFrame(arr)
    pprint(df)
except ValueError as e:
    print('Error catched: ', e)
    pprint(arr)
    for k,v in arr.items():
        print(k, 'N=', len(v))
```

"FAIL" produces such tree, where array [100,101,...] is assigned to value 10 in "single" instead od 100
```
root [2] tt->Scan("single:array")
***********************************************
*    Row   * Instance *    single *     array *
***********************************************
*        0 *        0 *        10 *       100 *
*        0 *        1 *           *       101 *
*        0 *        2 *           *       102 *
*        0 *        3 *           *       103 *
*        0 *        4 *           *       104 *
*        1 *        0 *       100 *        -1 *
*        1 *        1 *           *         0 *
*        1 *        2 *           *         1 *
*        2 *        0 *        -1 *        -1 *
*        2 *        1 *           *         0 *
*        2 *        2 *           *         1 *
***********************************************
```